### PR TITLE
🐛 fix(bootstrap): normalise client archive root so macOS can build

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -158,6 +158,24 @@ extract_archive() {
       ;;
     *) echo "Unsupported archive: $archive" >&2; exit 1 ;;
   esac
+
+  # Normalise the archive's own root to "vintagestory".
+  #
+  # Every caller below reads $dest/vintagestory, and only the Windows zip roots
+  # there: the macOS tarball roots at "Vintage Story.app" and the Linux tarball
+  # at "vintagestory" already. Without this, a macOS bootstrap downloads the
+  # right client, extracts it, and then fails on the very next line with
+  #   cp: .vanilla/win-x64/vintagestory/VintagestoryLib.dll: No such file
+  # having done the 607MB download first.
+  #
+  # Renaming rather than teaching each reader about layouts keeps the canonical
+  # path the one thing every script and every HintPath already agrees on.
+  if [[ ! -d "$dest/vintagestory" ]]; then
+    local roots=("$dest"/*/)
+    if [[ ${#roots[@]} -eq 1 && -d "${roots[0]}" ]]; then
+      mv "${roots[0]%/}" "$dest/vintagestory"
+    fi
+  fi
 }
 
 normalize_lf() {


### PR DESCRIPTION
A macOS bootstrap downloads the right client, extracts it, and then fails on the very next line:

  cp: .vanilla/win-x64/vintagestory/VintagestoryLib.dll: No such file or directory

having spent the 607MB download first. Every reader below expects $vanilla_dir/vintagestory, and only the Windows zip roots there — the macOS tarball roots at "Vintage Story.app". The extraction flattens the parent but not the archive's own root, so the canonical path is never created.

extract_archive now renames a single extracted root to vintagestory when that directory is not already present. Windows and Linux already root there, so it is a no-op for them; macOS gets the layout the rest of the script is written against. Renaming at extraction rather than teaching each reader about per-platform layouts keeps the canonical path the one thing every script and every HintPath already agrees on, which is what the comment above vanilla_dir says the design intends.

Both call sites benefit, including the re-extract path added for version mismatch.

Verified on macOS arm64 from a clean clone: bootstrap now runs through decompile, fork clone and patching to completion — 95 applied, 0 skipped, 0 failed — and dotnet build succeeds with 0 warnings and 0 errors.