### PR TITLE
🐛 fix(bootstrap): download the client archive atomically

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -508,8 +508,22 @@ try {
         if (-not (Test-Path $ClientArchive)) {
             $url = "https://cdn.vintagestory.at/gamefiles/stable/$exeName"
             Write-Host "Downloading $url (~570MB)"
-            Invoke-NativeStep { curl.exe -L --fail --progress-bar -o $ClientArchive $url }
-            if ($LASTEXITCODE -ne 0) { throw "Download failed: $url" }
+
+            # Written under a temporary name and moved into place only once curl has
+            # succeeded, so an interrupted download leaves nothing rather than a short file
+            # at the cache path. Without this, stopping the bootstrap during the ~570 MB
+            # download poisons the cache: the next run finds the file, reports "Using
+            # cached", and fails in innounp instead.
+            $partial = "$ClientArchive.partial"
+            Remove-Item -Force -ErrorAction SilentlyContinue $partial
+
+            Invoke-NativeStep { curl.exe -L --fail --progress-bar -o $partial $url }
+            if ($LASTEXITCODE -ne 0) {
+                Remove-Item -Force -ErrorAction SilentlyContinue $partial
+                throw "Download failed: $url"
+            }
+
+            Move-Item -Force $partial $ClientArchive
         } else {
             Write-Host "Using cached $ClientArchive"
         }
@@ -521,8 +535,19 @@ try {
             New-Item -ItemType Directory -Force -Path $toolsDir | Out-Null
             $innounpZip = Join-Path $toolsDir 'innounp-2.zip'
             Write-Host "Downloading innounp"
-            Invoke-NativeStep { curl.exe -L --fail --silent -o $innounpZip "https://github.com/jrathlev/InnoUnpacker-Windows-GUI/releases/download/ui_2_2_9/innounp-2.zip" }
-            if ($LASTEXITCODE -ne 0) { throw "Download failed: innounp-2.zip" }
+
+            # Same reasoning as the client archive above: small enough that the window is
+            # narrow, and a short zip here fails in Expand-Archive on every later run.
+            $innounpPartial = "$innounpZip.partial"
+            Remove-Item -Force -ErrorAction SilentlyContinue $innounpPartial
+
+            Invoke-NativeStep { curl.exe -L --fail --silent -o $innounpPartial "https://github.com/jrathlev/InnoUnpacker-Windows-GUI/releases/download/ui_2_2_9/innounp-2.zip" }
+            if ($LASTEXITCODE -ne 0) {
+                Remove-Item -Force -ErrorAction SilentlyContinue $innounpPartial
+                throw "Download failed: innounp-2.zip"
+            }
+
+            Move-Item -Force $innounpPartial $innounpZip
             Expand-Archive -Path $innounpZip -DestinationPath $toolsDir -Force
             $found = Get-ChildItem -Path $toolsDir -Recurse -Filter 'innounp.exe' | Select-Object -First 1
             if ($found -and $found.FullName -ne $innounp) {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -160,6 +160,31 @@ extract_archive() {
   esac
 }
 
+# Whether an archive can be read from end to end.
+#
+# The download below is atomic, so nothing this script writes can be short. A cache
+# created before that was true — or left by a kill -9, a full disk, or a machine losing
+# power — is short rather than absent, and the reuse check above only asks whether the
+# file exists. Reading it once costs seconds against a bootstrap measured in tens of
+# minutes, and turns "tar: unexpected end of file" into a second download.
+archive_is_complete() {
+  local archive="$1"
+  [[ -s "$archive" ]] || return 1
+
+  case "$archive" in
+    *.tar.gz|*.tgz) tar -tzf "$archive" >/dev/null 2>&1 ;;
+    *.zip)
+      if command -v unzip >/dev/null 2>&1; then
+        unzip -qt "$archive" >/dev/null 2>&1
+      else
+        python3 -c "import zipfile,sys; sys.exit(0 if zipfile.is_zipfile(sys.argv[1]) else 1)" \
+          "$archive" >/dev/null 2>&1
+      fi
+      ;;
+    *) return 0 ;;
+  esac
+}
+
 normalize_lf() {
   local root="$1"
   [[ -d "$root" ]] || return 0
@@ -221,14 +246,33 @@ download_client_archive() {
   local archive_path="$cache_dir/$archive_name"
 
   if [[ -f "$archive_path" ]]; then
-    echo "Using cached $archive_path" >&2
-    printf '%s\n' "$archive_path"
-    return
+    if archive_is_complete "$archive_path"; then
+      echo "Using cached $archive_path" >&2
+      printf '%s\n' "$archive_path"
+      return
+    fi
+
+    echo "Cached $archive_path is incomplete; downloading it again." >&2
+    rm -f "$archive_path"
   fi
 
   local url="https://cdn.vintagestory.at/gamefiles/stable/$archive_name"
   echo "Downloading $url" >&2
-  curl -L --fail --output "$archive_path" "$url"
+
+  # Written under a temporary name and moved into place only once curl has succeeded, so
+  # an interrupted download leaves nothing rather than a short file at the cache path.
+  # Without this, stopping the bootstrap during the ~500 MB download poisons the cache:
+  # the next run finds the file, reports "Using cached", and fails in tar instead.
+  local partial="$archive_path.partial"
+  rm -f "$partial"
+
+  if ! curl -L --fail --output "$partial" "$url"; then
+    rm -f "$partial"
+    echo "Download failed: $url" >&2
+    return 1
+  fi
+
+  mv -f "$partial" "$archive_path"
   printf '%s\n' "$archive_path"
 }
 


### PR DESCRIPTION
curl wrote straight to the cache path, so interrupting the ~500 MB download left a short file there. The reuse check only asks whether the file exists, so the next run reported "Using cached" and failed in tar or innounp instead — the cache stayed poisoned until somebody deleted it by hand, and nothing in the error pointed at the download.

The archive is now written under a .partial name and moved into place only once curl has succeeded, so an interrupted run leaves nothing behind. bootstrap.sh additionally reads a cached archive end to end before trusting it, which repairs a cache poisoned by an older revision, a kill -9 or a full disk; it costs a few seconds against a bootstrap measured in tens of minutes.

innounp's zip is downloaded the same way, for the same reason.