### PR TITLE
docs: add GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,74 @@
+name: Bug report
+description: Something in the game behaves differently from vanilla, or differently from a previous Optimum release.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, confirm the bug reproduces with Optimum's patches and shaders active, not only in vanilla Vintage Story. If it also happens in vanilla, report it to [VintageStory-Issues](https://github.com/anegostudios/VintageStory-Issues/issues) instead. For a crash or unhandled exception, use the Crash report form. For a conflict with another mod or shader, use the Mod or shader compatibility form.
+  - type: input
+    id: optimum-version
+    attributes:
+      label: Optimum version
+      description: From the launcher log line "[Optimum] Optimum vX.Y.Z", or the splash screen.
+      placeholder: "0.3.13"
+    validations:
+      required: true
+  - type: input
+    id: vs-version
+    attributes:
+      label: Vintage Story version
+      placeholder: "1.22.7"
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows
+        - Linux
+        - macOS
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Load a world with ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Attach a screenshot or short video if it helps show the problem.
+  - type: textarea
+    id: mods
+    attributes:
+      label: Mods loaded
+      description: List any mods, including shader packages. Try to reproduce with only Optimum active if possible.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I confirmed this does not happen on a stock vanilla Vintage Story client.
+          required: true
+        - label: I am running the latest Optimum release.
+          required: true

--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -1,0 +1,55 @@
+name: Mod or shader compatibility
+description: Optimum conflicts with another mod or shader package.
+labels: ["bug", "compatibility"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check `.optimum/shader-compatibility.json` in your data path first. If it already flags the mod as a conflict and disables a feature, say so below and describe what still goes wrong.
+  - type: input
+    id: conflicting-mod
+    attributes:
+      label: Conflicting mod or shader package
+      description: Name and version.
+      placeholder: "Ancestral Bliss Shaders 1.3.15"
+    validations:
+      required: true
+  - type: input
+    id: optimum-version
+    attributes:
+      label: Optimum version
+      placeholder: "0.3.13"
+    validations:
+      required: true
+  - type: input
+    id: vs-version
+    attributes:
+      label: Vintage Story version
+      placeholder: "1.22.7"
+    validations:
+      required: true
+  - type: textarea
+    id: symptom
+    attributes:
+      label: What happens
+      description: Crash, visual glitch, or disabled feature. Name the specific visual element if applicable (clouds, water, godrays, FSR).
+    validations:
+      required: true
+  - type: textarea
+    id: shader-compat
+    attributes:
+      label: Shader compatibility report
+      description: Paste the contents of `.optimum/shader-compatibility.json` from your data path.
+      render: json
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  - type: textarea
+    id: client-log
+    attributes:
+      label: Vintage Story client log
+      description: Attach `Logs/client-main.log` from your data path.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Building from Source
+    url: https://github.com/StratumServer/Optimum/wiki/Building-from-Source
+    about: Prerequisites and platform-specific build steps. Check this before filing an install or build failure.
+  - name: Settings
+    url: https://github.com/StratumServer/Optimum/wiki/Settings
+    about: Config file locations and the world-generation workaround keys.
+  - name: Vanilla bug
+    url: https://github.com/anegostudios/VintageStory-Issues/issues
+    about: If the same problem happens on a stock vanilla client, report it upstream instead.

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -1,0 +1,88 @@
+name: Crash report
+description: The client crashed, froze on load, or threw an unhandled exception.
+labels: ["bug", "crash"]
+body:
+  - type: input
+    id: optimum-version
+    attributes:
+      label: Optimum version
+      description: From the launcher log line "[Optimum] Optimum vX.Y.Z".
+      placeholder: "0.3.13"
+    validations:
+      required: true
+  - type: input
+    id: vs-version
+    attributes:
+      label: Vintage Story version
+      placeholder: "1.22.7"
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows
+        - Linux
+        - macOS
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: What was happening
+      description: What you were doing when it crashed. First frame of loading, world age, recent actions, graphics settings changed.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Leave blank if the crash is not reliably reproducible.
+  - type: textarea
+    id: trace
+    attributes:
+      label: Crash report or stack trace
+      description: Copy the text from the in-game Crash Reporter screen, or paste the exception from the log.
+      render: text
+      placeholder: |
+        System.InvalidOperationException: ...
+           at ...
+    validations:
+      required: true
+  - type: textarea
+    id: launcher-log
+    attributes:
+      label: Optimum launcher log
+      description: Attach or paste `Logs/optimum-launcher.log` from your data path. Full file, not a snippet.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: client-log
+    attributes:
+      label: Vintage Story client log
+      description: Attach `Logs/client-main.log` from your data path. Full file, not a snippet.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: shader-compat
+    attributes:
+      label: Shader compatibility report
+      description: If a shader or render-hook mod is installed, paste the contents of `.optimum/shader-compatibility.json` from your data path.
+      render: json
+  - type: textarea
+    id: mods
+    attributes:
+      label: Mods loaded
+      description: List any mods, including shader packages. Try to reproduce with only Optimum active if possible.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I confirmed this does not happen on a stock vanilla Vintage Story client.
+          required: true
+        - label: I am running the latest Optimum release.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,32 @@
+name: Feature or optimization suggestion
+description: Suggest a performance optimization, compatibility improvement, or installer change.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Optimum accepts performance optimizations, compatibility improvements, and installer or build changes. It does not accept gameplay, balance, or content changes; those belong in a mod. See [CONTRIBUTING.md](https://github.com/StratumServer/Optimum/blob/main/CONTRIBUTING.md).
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is the actual problem you are trying to solve. Not the solution yet.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: This does not change gameplay, balance, or add content.
+          required: true

--- a/.github/ISSUE_TEMPLATE/install.yml
+++ b/.github/ISSUE_TEMPLATE/install.yml
@@ -1,0 +1,75 @@
+name: Install, update, or build failure
+description: The installer, updater, or a from-source build failed before the game launched.
+labels: ["bug", "installer"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Most install failures are platform-specific. Check the [Building from Source](https://github.com/StratumServer/Optimum/wiki/Building-from-Source) wiki page for your platform before filing.
+  - type: dropdown
+    id: method
+    attributes:
+      label: Install method
+      options:
+        - Prebuilt installer or updater
+        - bootstrap.sh / build from source
+        - Package manager (AUR, Flatpak, etc.)
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows
+        - Linux
+        - macOS
+    validations:
+      required: true
+  - type: input
+    id: from-version
+    attributes:
+      label: Updating from version
+      description: Leave blank on a fresh install.
+      placeholder: "0.3.12"
+  - type: input
+    id: to-version
+    attributes:
+      label: Installing or updating to version
+      placeholder: "0.3.13"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps taken
+      description: Exact commands run, or exact clicks in the installer UI.
+      placeholder: |
+        1. Downloaded the v0.3.13 release
+        2. Ran ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: where
+    attributes:
+      label: Where it stopped
+      description: The last visible step, phase, or progress message before it failed or hung.
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Full error output or log
+      description: Paste the exact error text, or attach the log. Do not paraphrase the error.
+      render: text
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I read the Building from Source wiki page for my platform.
+          required: true

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -1,0 +1,40 @@
+name: Performance regression
+description: FPS, frame time, or stutter got worse, especially compared to an earlier Optimum release.
+labels: ["bug", "performance"]
+body:
+  - type: input
+    id: optimum-version
+    attributes:
+      label: Optimum version
+      placeholder: "0.3.13"
+    validations:
+      required: true
+  - type: input
+    id: last-good-version
+    attributes:
+      label: Last version without the regression
+      description: Leave blank if you are not sure, or if this is your first Optimum version.
+      placeholder: "0.3.12"
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware
+      placeholder: "RTX 3060, Ryzen 5 5600, 32 GB RAM"
+    validations:
+      required: true
+  - type: textarea
+    id: symptom
+    attributes:
+      label: What you observe
+      description: FPS numbers, frame time, or a stutter pattern. Before and after numbers if you have them.
+    validations:
+      required: true
+  - type: textarea
+    id: world
+    attributes:
+      label: World and settings
+      description: Render distance, graphics settings, FSR or render scale setting, world age, anything unusual built nearby.
+  - type: textarea
+    id: mods
+    attributes:
+      label: Mods loaded

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,14 @@
+name: Question or documentation issue
+description: Ask how something works, or report a wiki or README mismatch with the current source.
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Open-ended questions and documentation mismatches go here. No fixed structure required, just say what you found or what you want to know. For a doc mismatch, name the wiki page and the current source it disagrees with if you know it.
+  - type: textarea
+    id: body
+    attributes:
+      label: Question or mismatch
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

The tracker had no issue templates, so every report came in as free text with no version, platform, or log attached (see the recent triage in the private tracking log for how much of that had to be reconstructed by hand). Adds seven issue forms matching the shapes that actually recur across the 33 issues filed so far, plus a config that routes vanilla-only bugs upstream and build/settings questions to the wiki instead of a blank issue.

- `crash.yml`: client crash or unhandled exception. Requires the crash report/trace, the Optimum launcher log, and the Vintage Story client log; requests the shader compatibility report when relevant.
- `install.yml`: installer, updater, or from-source build failure. Separates install method and platform, since the fix path differs by both; asks where it stopped and the exact error output.
- `compatibility.yml`: conflict with another mod or shader package. Asks for `.optimum/shader-compatibility.json` directly, since the scanner already flags most known conflicts.
- `bug.yml`: general incorrect behavior, not a crash.
- `performance.yml`: FPS/frame time regression, with a field for the last version that did not have it.
- `feature.yml`: optimization or compatibility suggestions, with the gameplay-scope checkbox from CONTRIBUTING.md.
- `question.yml`: open-ended questions and doc mismatches that do not fit a structured form.
- `config.yml`: disables blank issues, links Building from Source and Settings wiki pages, and redirects vanilla-only bugs to `anegostudios/VintageStory-Issues`.

Labels used (`bug`, `crash`, `installer`, `compatibility`, `performance`, `enhancement`, `question`) all already exist on the repo.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on all 8 files
- [x] `git diff --check` clean
- [x] Scanned the diff for private paths, credentials, and AI traces