### PR TITLE
docs: prefill a title tag on each issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Something in the game behaves differently from vanilla, or differently from a previous Optimum release.
+title: "[Bug] "
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -1,5 +1,6 @@
 name: Mod or shader compatibility
 description: Optimum conflicts with another mod or shader package.
+title: "[Compatibility] "
 labels: ["bug", "compatibility"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -1,5 +1,6 @@
 name: Crash report
 description: The client crashed, froze on load, or threw an unhandled exception.
+title: "[Crash] "
 labels: ["bug", "crash"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,5 +1,6 @@
 name: Feature or optimization suggestion
 description: Suggest a performance optimization, compatibility improvement, or installer change.
+title: "[Feature] "
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/install.yml
+++ b/.github/ISSUE_TEMPLATE/install.yml
@@ -1,5 +1,6 @@
 name: Install, update, or build failure
 description: The installer, updater, or a from-source build failed before the game launched.
+title: "[Installer] "
 labels: ["bug", "installer"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -1,5 +1,6 @@
 name: Performance regression
 description: FPS, frame time, or stutter got worse, especially compared to an earlier Optimum release.
+title: "[Performance] "
 labels: ["bug", "performance"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,11 +1,12 @@
 name: Question or documentation issue
 description: Ask how something works, or report a wiki or README mismatch with the current source.
+title: "[Question] "
 labels: ["question"]
 body:
   - type: markdown
     attributes:
       value: |
-        Open-ended questions and documentation mismatches go here. No fixed structure required, just say what you found or what you want to know. For a doc mismatch, name the wiki page and the current source it disagrees with if you know it.
+        Open-ended questions and documentation mismatches go here. No fixed structure required, just say what you found or what you want to know. For a doc mismatch, name the wiki page and the current source it disagrees with if you know it, and change the title's `[Question]` tag to `[Docs]`.
   - type: textarea
     id: body
     attributes:


### PR DESCRIPTION
## Summary

Follow-up to #34. The nine existing issues (#25-#33) used version, platform, or tool-name brackets inconsistently, and one (#29) had no tag at all. Retitled all nine to a single bracket-tag convention matching each issue's primary label ([Bug], [Crash], [Installer], [Compatibility], [Question], with [Docs] kept for #32 since it already used that exact tag). This PR makes the convention durable by adding a `title:` prefill to each of the seven forms, so new issues start with the right tag instead of relying on the reporter or a later rename.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on all 7 changed files
- [x] `git diff --check` clean