### PR TITLE
docs: point settings documentation at ModConfig/optimum.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,30 @@ make build
 
 Open the .dmg and drag Optimum.app to Applications. Requires .NET 10 SDK, bash, python3, git, curl, perl.
 
+## Settings
+
+Optimum persists its runtime settings to `ModConfig/optimum.json` inside your
+Vintage Story data path. The file is created with defaults on first run.
+The `.optimum/` directory under the same data path holds launcher state
+(donor assemblies, the patched-assembly cache, and the shader compatibility
+report), not user settings.
+
+The data path depends on the platform:
+
+| Platform | Data path |
+|---|---|
+| Windows | `%APPDATA%\VintagestoryData` |
+| Linux | `~/.config/VintagestoryData` |
+| macOS | `~/Library/Application Support/VintagestoryData` |
+
+Older macOS installs may still have `~/.config/VintagestoryData`; the game
+moves that folder to the new location on first run.
+
+The client reads the file once at startup, so a full restart is required
+after editing it. When troubleshooting world-generation problems, the four
+relevant keys are `ChunkReadPoolEnabled`, `ChunkReadPoolWorkers`,
+`ChunkDeserializeParallel`, and `ChunkDeserializeParallelMinY`.
+
 ## Build
 
 ### Targeting a Vintage Story version

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -226,9 +226,9 @@ install_optimum() {
     # Step 5: Remove vanilla launcher.
     rm -f "$install_dir/Vintagestory" 2>/dev/null
 
-    # Step 6: Create .optimum config dir.
+    # Step 6: Create the launcher state dir. Runtime settings live in
+    # ModConfig/optimum.json under the VS data path, not here.
     mkdir -p "$install_dir/.optimum"
-    [[ -f "$install_dir/.optimum/optimum.json" ]] || echo '{}' > "$install_dir/.optimum/optimum.json"
     echo "$OPTIMUM_VERSION" > "$install_dir/.optimum/version"
 
     cat > "$install_dir/run-optimum.sh" <<'LAUNCHER'


### PR DESCRIPTION
The settings path confusion from #32 has two in-repository sources: nothing documents where `ModConfig/optimum.json` actually lives, and the macOS installer creates a misleading `.optimum/optimum.json` that nothing reads.

## Changes

- README.md: new Settings section documenting `ModConfig/optimum.json` under the VS data path, the per-platform data paths (verified against `VintagestoryApi/Config/GamePaths.cs`), what `.optimum/` holds instead (donors, patched cache, shader compatibility report), the full-restart requirement, and the four world-generation troubleshooting keys (`ChunkReadPoolEnabled`, `ChunkReadPoolWorkers`, `ChunkDeserializeParallel`, `ChunkDeserializeParallelMinY`, matching the guidance in #31).
- scripts/install-macos.sh: stop writing an empty `.optimum/optimum.json` into the install folder. The version marker stays; only the obsolete file creation goes away.

## Verification

- `bash -n scripts/install-macos.sh` passes; shellcheck reports only pre-existing infos on untouched lines.
- `make check` passes.
- No tracked file still references `.optimum/optimum.json`.

## Wiki

The wiki itself cannot take a pull request, so I pushed the matching corrections directly to the wiki (`4d29f2f`): the Persistence and config-file-only sections of [[Settings]], the installed-files table in [[Installation]], the failure-behavior paragraph in [[Compatibility]], and the pregen mention in [[Features]]. With this PR merged, no user-facing surface still claims that settings live at `.optimum/optimum.json`.

Closes #32.
