### PR TITLE
fix: stop inheriting GIT_DIR during bootstrap clones

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -14,6 +14,13 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 
+# A GIT_DIR inherited from the calling environment (some tools and shell rc
+# files export it) overrides repository discovery for every git call below:
+# the clone succeeds, then the very next `git -C <clone> config` dies with
+# "fatal: not in a git directory". Drop it, along with its siblings, so this
+# script only ever talks to repositories it names explicitly.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 usage() {
   cat <<'EOF'
 Usage: scripts/bootstrap.sh [--version VERSION] [--client-archive PATH] [--refresh]
@@ -455,6 +462,12 @@ if [[ -f "$forks_file" ]]; then
       rm -rf "$base"
       echo "Cloning $name at $ref"
       git -c core.autocrlf=false -c core.eol=lf clone --quiet "$url" "$base"
+      if [[ ! -d "$base/.git" ]]; then
+        echo "Cloning $name succeeded but left no repository at $base" >&2
+        echo "Check the URL in forks.json and your git environment (GIT_DIR," >&2
+        echo "GIT_WORK_TREE), then retry." >&2
+        exit 1
+      fi
       git -C "$base" config core.autocrlf false
       git -C "$base" config core.eol lf
       git -C "$base" checkout --quiet "$ref"


### PR DESCRIPTION
A bootstrap failure reported in #23 (`fatal: not in a git directory` immediately after `Cloning VintagestoryApi`) reproduces whenever the calling environment exports `GIT_DIR`. I confirmed the mechanism with a minimal harness: with `GIT_DIR` pointing at an invalid path, `git clone` itself succeeds, and the very next `git -C <clone> config core.autocrlf false` dies with exactly that message and exit 128, because `GIT_DIR` overrides repository discovery.

## Changes

- scripts/bootstrap.sh unsets `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` up front, so the script only ever talks to repositories it names explicitly.
- The clone loop now verifies each clone actually produced a repository before running `git config`/`git checkout` on it. If some future variant of this bug appears, it fails with an actionable message (check forks.json URL and git environment) instead of a bare git error.

## Verification

- Minimal harness: without the fix, `git -C <clone> config` exits 128 with `fatal: not in a git directory`; with the unset, the same sequence completes.
- Full end-to-end run on this host: fresh checkout at this commit with an invalid `GIT_DIR=/tmp/nonexistent.git` exported, caches reused, `build/snapshot/VintagestoryApi` removed to force the exact step from the report. Without the fix this failed at the reported spot; with the fix, bootstrap completed: `Cloning VintagestoryApi at 63d33f7...` passed, 116 patches applied, 0 skipped, 0 failed, exit 0.
- `bash -n scripts/bootstrap.sh` passes; shellcheck reports only pre-existing findings.

## Scope notes

The same `git -C <clone>` pattern exists in bootstrap.ps1 for Windows packaging hosts. An inherited `GIT_DIR` is rare there, so I kept this PR scoped to the reported bash path; happy to mirror the guard in a follow-up.
