### PR TITLE
fix: honor managed --dataPath when a manager launches Vintagestory.exe

### DIFF
--- a/Optimum.Launcher.Tests/DataPathArgumentTests.cs
+++ b/Optimum.Launcher.Tests/DataPathArgumentTests.cs
@@ -1,0 +1,41 @@
+using Optimum.Launcher;
+using Xunit;
+
+namespace Optimum.Launcher.Tests;
+
+public sealed class DataPathArgumentTests
+{
+    [Theory]
+    [InlineData("--dataPath", "/managed")]
+    [InlineData("-d", "/managed")]
+    public void SpaceSeparatedValueIsExtracted(string flag, string value)
+    {
+        Assert.Equal(value, Program.ResolveDataPath([flag, value]));
+    }
+
+    [Theory]
+    [InlineData("--dataPath=/managed")]
+    [InlineData("-d=/managed")]
+    public void EqualsSeparatedValueIsExtracted(string arg)
+    {
+        Assert.Equal("/managed", Program.ResolveDataPath([arg]));
+    }
+
+    [Fact]
+    public void MissingFlagReturnsNull()
+    {
+        Assert.Null(Program.ResolveDataPath(["--other", "x"]));
+    }
+
+    [Fact]
+    public void FlagWithoutValueReturnsNull()
+    {
+        Assert.Null(Program.ResolveDataPath(["--dataPath"]));
+    }
+
+    [Fact]
+    public void FirstMatchWins()
+    {
+        Assert.Equal("/first", Program.ResolveDataPath(["--dataPath=/first", "--dataPath", "/second"]));
+    }
+}

--- a/Optimum.Launcher/Program.cs
+++ b/Optimum.Launcher/Program.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
+[assembly: InternalsVisibleTo("Optimum.Launcher.Tests")]
+
 namespace Optimum.Launcher;
 
 /// <summary>
@@ -612,14 +614,25 @@ public static class Program
     }
 
     /// <summary>
-    /// Extracts --dataPath from CLI args (same as VS does).
+    /// Extracts --dataPath from CLI args, matching the forms the game itself
+    /// accepts through CommandLineParser: "--dataPath VALUE" and
+    /// "--dataPath=VALUE", plus the "-d" convenience forms. Returns null when
+    /// absent so the caller falls back to datapath.cfg and then the install
+    /// directory.
     /// </summary>
-    private static string? ResolveDataPath(string[] args)
+    internal static string? ResolveDataPath(string[] args)
     {
-        for (int i = 0; i < args.Length - 1; i++)
+        for (int i = 0; i < args.Length; i++)
         {
-            if (args[i] is "--dataPath" or "-d")
-                return args[i + 1];
+            string arg = args[i];
+            if (arg is "--dataPath" or "-d")
+            {
+                return i + 1 < args.Length ? args[i + 1] : null;
+            }
+            if (arg.StartsWith("--dataPath=", StringComparison.Ordinal))
+                return arg["--dataPath=".Length..];
+            if (arg.StartsWith("-d=", StringComparison.Ordinal))
+                return arg["-d=".Length..];
         }
 
         var configPath = Path.Combine(AppContext.BaseDirectory, "datapath.cfg");

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -333,9 +333,13 @@ fi
 # 6. Rebrand: rename launcher, repoint run.sh, swap icon, brand .desktop
 # ============================================================================
 
+# Keep the vanilla-named binary too: managers like StoryForge hardcode
+# 'vintagestory' when launching the game, and both names load the same
+# patched Vintagestory.dll through the embedded entry name, so either
+# entrypoint runs Optimum.
 if [[ -f "$STAGE_DIR/Vintagestory" ]]; then
-    mv "$STAGE_DIR/Vintagestory" "$STAGE_DIR/Optimum"
-    chmod +x "$STAGE_DIR/Optimum"
+    cp -f "$STAGE_DIR/Vintagestory" "$STAGE_DIR/Optimum"
+    chmod +x "$STAGE_DIR/Vintagestory" "$STAGE_DIR/Optimum"
 else
     echo "Warning: launcher 'Vintagestory' not found in archive." >&2
 fi

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -229,9 +229,12 @@ if [[ -n "$BAD_SHADERS" ]]; then
 fi
 
 # 6. Rebrand: rename launcher, swap icon, rewrite Info.plist.
+# Keep the vanilla-named binary too so managers that hardcode 'vintagestory'
+# still reach Optimum; CFBundleExecutable stays Optimum. Both copies load the
+# same patched Vintagestory.dll through the embedded entry name.
 if [[ -f "$APP_DIR/Vintagestory" ]]; then
-    mv "$APP_DIR/Vintagestory" "$APP_DIR/Optimum"
-    chmod +x "$APP_DIR/Optimum"
+    cp -f "$APP_DIR/Vintagestory" "$APP_DIR/Optimum"
+    chmod +x "$APP_DIR/Vintagestory" "$APP_DIR/Optimum"
 else
     echo "Warning: launcher 'Vintagestory' not found in bundle." >&2
 fi

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -126,6 +126,12 @@ try {
     foreach ($launcherFile in @('Optimum.exe', 'Optimum.dll', 'Optimum.deps.json', 'Optimum.runtimeconfig.json')) {
         Copy-Item -Force (Join-Path $launcherOut $launcherFile) $stageDir
     }
+    # Managers that launch the game executable by its vanilla name
+    # (StoryForge launches Vintagestory.exe directly) must get the Optimum
+    # launcher, not a vanilla start. The apphost embeds the managed entry
+    # name (Optimum.dll), so a byte copy still loads and runs the launcher;
+    # Optimum.runtimeconfig.json and Optimum.dll are already staged above.
+    Copy-Item -Force (Join-Path $launcherOut 'Optimum.exe') (Join-Path $stageDir 'Vintagestory.exe')
     # Native assets for the launcher's patch-progress splash screen (OpenTK's
     # GLFW, SkiaSharp's text renderer). .NET's default native resolver looks
     # for these under runtimes/<rid>/native/ relative to the app base


### PR DESCRIPTION
Fixes #28, where a manager launches Optimum by the game's vanilla executable name and reports that the managed `--dataPath` is not honored.

## What I found

StoryForge hardcodes the game executable: in `src/bun/controllers/installations.ts` it always runs `vintagestory.exe --dataPath <path>` (or `vintagestory` on Linux/macOS), never `Optimum.exe`. The Windows package kept `Vintagestory.exe` as the vanilla apphost, so that launch started a vanilla client and never reached the Optimum launcher. On Linux and macOS the packaging renamed the `vintagestory` binary to `Optimum`, removing the exact name managers hardcode, so those launches could not find Optimum at all.

Separately, the launcher's own `--dataPath` resolver only accepted the space-separated form, while the game parses the flag through CommandLineParser, which also accepts `--dataPath=VALUE`. A caller using the equals form would get a vanilla-correct game but a launcher cache, shader scan, and log written to the wrong location.

## Changes

- `scripts/package.ps1`: stage the Optimum apphost over `Vintagestory.exe`, so a manager that launches `Vintagestory.exe` runs the Optimum launcher, which then forwards `--dataPath` to the game.
- `scripts/package-linux.sh`: copy the launcher to `Optimum` instead of renaming it away, keeping `vintagestory` as a working entrypoint.
- `scripts/package-macos.sh`: same copy instead of rename inside the app bundle; `CFBundleExecutable` stays `Optimum`.
- `Optimum.Launcher/Program.cs`: `ResolveDataPath` now accepts `--dataPath=VALUE` and `-d=VALUE` in addition to the space-separated forms.
- `Optimum.Launcher.Tests/DataPathArgumentTests.cs`: covers all four forms plus the missing-value and first-match-wins cases.

Both names load the same patched `Vintagestory.dll` through the apphost's embedded entry name, so either entrypoint runs Optimum.

## Verification

- `dotnet test Optimum.Launcher.Tests` passes: 13 passed, 0 failed.
- Apphost rename verified empirically on this host: copying the built `Optimum` apphost to `Vintagestory` (keeping `Optimum.dll`, `Optimum.deps.json`, `Optimum.runtimeconfig.json`) runs the launcher and prints `[Optimum] Optimum v0.3.13`, confirming the embedded-entry-name mechanism.
- Linux package built end to end on this host (`package-linux.sh --format targz`): the staged folder contains `Vintagestory` and `Optimum` with identical bytes, both executable, `run.sh` still points at `./Optimum`, and the apphost embeds `Vintagestory.dll` (the Optimum-built game assembly).
- `package.ps1` parses cleanly under PowerShell; `bash -n` passes for both changed shell scripts.

## Scope notes

macOS is verified by syntax only, not by running `package-macos.sh` (it needs the macOS client archive and builds a `.dmg`). The Windows and Linux paths are verified end to end as described above.
