### PR TITLE
fix(installer): fail closed on partial runtime donors

### DIFF
--- a/Optimum.Tests/installer-release-coverage-tests.cs
+++ b/Optimum.Tests/installer-release-coverage-tests.cs
@@ -230,6 +230,106 @@ public class InstallerReleaseCoverageTests
     }
 
     [Fact]
+    public void RuntimeDonorPatchGatesValidateEveryMandatoryProjectBeforeApplying()
+    {
+        string bash = Read("scripts/runtime-donor-patch-gate.sh");
+        string bashPreparation = Read("scripts/prepare-runtime-donors.sh");
+        string powershell = Read("scripts/prepare-runtime-donors.ps1");
+
+        Assert.Contains("runtime-donor-patch-gate.sh", bashPreparation);
+        Assert.Contains("runtime_projects=(VSEssentials VSSurvivalMod)", bash);
+        Assert.Contains("runtime_patch_failures=()", bash);
+        Assert.Contains("Runtime donor compatibility gate failed:", bash);
+        Assert.Contains("exit 1", bash);
+        int bashFailureGate = bash.IndexOf("Runtime donor compatibility gate failed:", StringComparison.Ordinal);
+        int bashApply = bash.IndexOf(
+            "git -C \"$repo_root\" apply \\",
+            bashFailureGate,
+            StringComparison.Ordinal);
+        Assert.True(bashFailureGate >= 0, "Bash donor failure gate is missing");
+        Assert.True(bashApply > bashFailureGate, "Bash applies a patch before its compatibility gate");
+
+        Assert.Contains("$runtimeProjects = @('VSEssentials', 'VSSurvivalMod')", powershell);
+        Assert.Contains("$runtimePatchFailures = @()", powershell);
+        Assert.Contains("$patchExitCode = $LASTEXITCODE", powershell);
+        Assert.Contains("2>&1 |", powershell);
+        Assert.Contains("git apply --check failed without diagnostic output.", powershell);
+        Assert.Contains("Runtime donor compatibility gate failed:", powershell);
+        int powershellFailureGate = powershell.IndexOf("Runtime donor compatibility gate failed:", StringComparison.Ordinal);
+        int powershellApply = powershell.IndexOf(
+            "git -C $repoRoot apply",
+            powershellFailureGate,
+            StringComparison.Ordinal);
+        Assert.True(powershellFailureGate >= 0, "PowerShell donor failure gate is missing");
+        Assert.True(powershellApply > powershellFailureGate, "PowerShell applies a patch before its compatibility gate");
+    }
+
+    [Fact]
+    public void BashRuntimeDonorPatchGateRejectsPartialCompatibility()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        string gate = PatchReader.FindRepositoryFile("scripts/runtime-donor-patch-gate.sh");
+        DirectoryInfo tempDirectory = Directory.CreateTempSubdirectory("optimum-runtime-gate-");
+
+        try
+        {
+            string runtimeRoot = Path.Combine(tempDirectory.FullName, "runtime");
+            string patchesRoot = Path.Combine(tempDirectory.FullName, "patches", "runtime");
+            string goodTarget = Path.Combine(runtimeRoot, "VSEssentials", "Good.cs");
+            Directory.CreateDirectory(Path.GetDirectoryName(goodTarget)!);
+            Directory.CreateDirectory(Path.Combine(patchesRoot, "VSEssentials"));
+            Directory.CreateDirectory(Path.Combine(patchesRoot, "VSSurvivalMod"));
+            File.WriteAllText(goodTarget, "old\n");
+            File.WriteAllText(
+                Path.Combine(patchesRoot, "VSEssentials", "Good.cs.patch"),
+                """
+                diff --git a/VSEssentials/Good.cs b/VSEssentials/Good.cs
+                --- a/VSEssentials/Good.cs
+                +++ b/VSEssentials/Good.cs
+                @@ -1 +1 @@
+                -old
+                +new
+                """.Replace("                ", ""));
+            File.WriteAllText(
+                Path.Combine(patchesRoot, "VSSurvivalMod", "Missing.cs.patch"),
+                """
+                diff --git a/VSSurvivalMod/Missing.cs b/VSSurvivalMod/Missing.cs
+                --- a/VSSurvivalMod/Missing.cs
+                +++ b/VSSurvivalMod/Missing.cs
+                @@ -1 +1 @@
+                -missing
+                +new
+                """.Replace("                ", ""));
+
+            ProcessStartInfo startInfo = new("bash")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            startInfo.ArgumentList.Add(gate);
+            startInfo.ArgumentList.Add(tempDirectory.FullName);
+            startInfo.ArgumentList.Add("runtime");
+            using Process process = Process.Start(startInfo)!;
+            string output = process.StandardOutput.ReadToEnd();
+            string error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            Assert.NotEqual(0, process.ExitCode);
+            Assert.Contains("Runtime donor compatibility gate failed", output + error);
+            Assert.Equal("old\n", File.ReadAllText(goodTarget));
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void RuntimePatchesHaveASeparateExactDonorPipeline()
     {
         string bootstrap = Read("scripts/bootstrap.sh");

--- a/scripts/prepare-runtime-donors.ps1
+++ b/scripts/prepare-runtime-donors.ps1
@@ -305,19 +305,34 @@ Exclude-CompileItems $survivalProject @(
 Resolve-ProjectReferences $essentialsProject
 Resolve-ProjectReferences $survivalProject
 
-foreach ($project in @('VSEssentials', 'VSSurvivalMod')) {
+$runtimeProjects = @('VSEssentials', 'VSSurvivalMod')
+$runtimePatchFailures = @()
+foreach ($project in $runtimeProjects) {
     $patchRoot = Join-Path $repoRoot "patches/runtime/$project"
     Get-ChildItem -Path $patchRoot -Filter '*.patch' -Recurse -File |
         Sort-Object FullName |
         ForEach-Object {
             $patchPath = $_.FullName
-            Invoke-NativeStep {
-                & git -C $repoRoot apply --check --directory='.build/runtime-donors' --whitespace=nowarn $patchPath *> $null
+            $patchOutput = Invoke-NativeStep {
+                & git -C $repoRoot apply --check --directory='.build/runtime-donors' --whitespace=nowarn $patchPath 2>&1 |
+                    Out-String
             }
-            if ($LASTEXITCODE -ne 0) {
-                throw "Runtime donor unavailable: $project requires a patch refresh for $($_.Name)."
+            $patchExitCode = $LASTEXITCODE
+            if ($patchExitCode -ne 0) {
+                $details = ([string]$patchOutput).Trim()
+                if (-not $details) {
+                    $details = 'git apply --check failed without diagnostic output.'
+                }
+                $runtimePatchFailures += "$project requires a patch refresh for $($_.Name): $details"
             }
         }
+}
+if ($runtimePatchFailures.Count -gt 0) {
+    throw "Runtime donor compatibility gate failed:`n  $($runtimePatchFailures -join "`n  ")"
+}
+
+foreach ($project in $runtimeProjects) {
+    $patchRoot = Join-Path $repoRoot "patches/runtime/$project"
     Get-ChildItem -Path $patchRoot -Filter '*.patch' -Recurse -File |
         Sort-Object FullName |
         ForEach-Object {

--- a/scripts/prepare-runtime-donors.sh
+++ b/scripts/prepare-runtime-donors.sh
@@ -4,15 +4,6 @@ if (set -o pipefail 2>/dev/null); then
     set -o pipefail
 fi
 
-# sort -z is GNU coreutils; macOS sort lacks it. Fall back to plain sort
-# (patch filenames have no embedded newlines, so null-delimiting is
-# cosmetic and not required for correctness).
-if echo | sort -z 2>/dev/null; then
-    sort_z() { sort -z; }
-else
-    sort_z() { sort; }
-fi
-
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 vanilla_dir="${VANILLA_DIR:-$repo_root/.vanilla/win-x64/vintagestory}"
@@ -330,30 +321,8 @@ resolve_references() {
 resolve_references "$essentials_project"
 resolve_references "$survival_project"
 
-eligible_projects=()
-for project in VSEssentials VSSurvivalMod; do
-    project_ready=1
-    while IFS= read -r -d '' patch; do
-        if ! git -C "$repo_root" apply --check \
-            --directory=".build/runtime-donors" \
-            --whitespace=nowarn \
-            "$patch"; then
-            echo "Runtime donor unavailable: $project requires a patch refresh for $(basename "$patch")." >&2
-            project_ready=0
-            break
-        fi
-    done < <(find "$repo_root/patches/runtime/$project" -name '*.patch' -print0 | sort_z)
-
-    if [[ "$project_ready" == "1" ]]; then
-        while IFS= read -r -d '' patch; do
-            git -C "$repo_root" apply \
-                --directory=".build/runtime-donors" \
-                --whitespace=nowarn \
-                "$patch"
-        done < <(find "$repo_root/patches/runtime/$project" -name '*.patch' -print0 | sort_z)
-        eligible_projects+=("$project")
-    fi
-done
+"$repo_root/scripts/runtime-donor-patch-gate.sh" "$repo_root" ".build/runtime-donors"
+eligible_projects=(VSEssentials VSSurvivalMod)
 
 # Optimum-owned new types are source overlays, not decompiled game source.
 if [[ " ${eligible_projects[*]} " == *" VSEssentials "* ]]; then

--- a/scripts/runtime-donor-patch-gate.sh
+++ b/scripts/runtime-donor-patch-gate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -eu
+if (set -o pipefail 2>/dev/null); then
+    set -o pipefail
+fi
+
+if [[ "$#" -ne 2 ]]; then
+    echo "Usage: $0 <repository-root> <runtime-root-relative-to-repository>" >&2
+    exit 2
+fi
+
+repo_root="$1"
+runtime_root="$2"
+patch_root="$repo_root/patches/runtime"
+
+if echo | sort -z 2>/dev/null; then
+    sort_z() { sort -z; }
+else
+    sort_z() { sort; }
+fi
+
+runtime_projects=(VSEssentials VSSurvivalMod)
+runtime_patch_failures=()
+for project in "${runtime_projects[@]}"; do
+    while IFS= read -r -d '' patch; do
+        if ! patch_error="$(git -C "$repo_root" apply --check \
+            --directory="$runtime_root" \
+            --whitespace=nowarn \
+            "$patch" 2>&1)"; then
+            printf '%s\n' "$patch_error" >&2
+            runtime_patch_failures+=("$project requires a patch refresh for $(basename "$patch")")
+        fi
+    done < <(find "$patch_root/$project" -name '*.patch' -print0 | sort_z)
+done
+
+if [[ "${#runtime_patch_failures[@]}" != "0" ]]; then
+    echo "Runtime donor compatibility gate failed:" >&2
+    printf '  %s\n' "${runtime_patch_failures[@]}" >&2
+    exit 1
+fi
+
+for project in "${runtime_projects[@]}"; do
+    while IFS= read -r -d '' patch; do
+        git -C "$repo_root" apply \
+            --directory="$runtime_root" \
+            --whitespace=nowarn \
+            "$patch"
+    done < <(find "$patch_root/$project" -name '*.patch' -print0 | sort_z)
+done
+
+printf 'Runtime donor patches applied for:'
+printf ' %s' "${runtime_projects[@]}"
+printf '\n'


### PR DESCRIPTION
## Summary

Addresses #27.

The Bash runtime-donor preparation path could skip a mandatory project after a patch preflight failure, build the remaining donor, and exit successfully. The package could then continue with an incomplete donor set.

This PR:

- validates every VSEssentials and VSSurvivalMod runtime patch before applying any patch;
- fails before donor compilation when any mandatory patch is unavailable;
- keeps the Bash and PowerShell gates aligned;
- preserves the `git apply --check` diagnostic in the Windows error; and
- adds an executable regression fixture proving that a failed later donor leaves an earlier donor unapplied.

## Investigation

The Windows report names `VSEssentials/AStar.cs.patch`. I rebuilt the exact pinned 1.22.7 donor snapshot on Linux and ran both donor preparation paths. Both completed the VSEssentials and VSSurvivalMod builds, so the Windows-specific AStar mismatch was not reproduced and the patch was not refreshed speculatively.

I later repeated the check on real Windows PowerShell 5.1 with Git for Windows 2.55, since the original report is Windows-only. I reversed the AStar patch to recover the pristine decompiled donor, then ran `git apply --check` against it once as decompiled and once with every line ending forced to CRLF, to cover a native Windows decompile producing different line endings than the Linux one. Both applied cleanly under `core.autocrlf=true`. The AStar mismatch still did not reproduce, so its root cause stays open. This PR does not depend on finding it: the gate closes the class of failure regardless of what makes an individual patch go stale.

The all-or-nothing gate follows the failure-handling pattern used in Stratum #177.

## Verification

Passed:

- `make check`
- `make build`
- `make check-patches`
- `make check-compat`
- `make check-shaders`
- Bash and PowerShell runtime-donor preparation
- 22 installer release coverage tests, including the partial-donor fixture

The full `make test` run reached 644 passed and 34 skipped. It also reports five unrelated baseline failures in unchanged coverage for Windows path normalization, FSR terrain bias, and entity render ownership.

I also ran the fail-closed block from `prepare-runtime-donors.ps1` directly under real Windows PowerShell 5.1 (Desktop edition), reading the block from the file at run time instead of retyping it, against two fixtures: a partial-donor case where one project's patch fails `--check`, and an all-compatible case. The partial case threw `Runtime donor compatibility gate failed` and left the compatible project's target file untouched. The compatible case applied both patches. This is the first time the PowerShell gate has been exercised end to end rather than checked by string assertion.

The fail-closed behavior is now verified on the platform it protects, in both the failure and success paths, so this is out of draft. The AStar mismatch that opened #27 is a separate, still-open investigation; it does not bear on whether this gate works.
