### PR TITLE
Promote dev to main: runtime-donor fail-closed gate and installer fixes

### DIFF
--- a/Optimum.Launcher.Tests/DataPathArgumentTests.cs
+++ b/Optimum.Launcher.Tests/DataPathArgumentTests.cs
@@ -1,0 +1,41 @@
+using Optimum.Launcher;
+using Xunit;
+
+namespace Optimum.Launcher.Tests;
+
+public sealed class DataPathArgumentTests
+{
+    [Theory]
+    [InlineData("--dataPath", "/managed")]
+    [InlineData("-d", "/managed")]
+    public void SpaceSeparatedValueIsExtracted(string flag, string value)
+    {
+        Assert.Equal(value, Program.ResolveDataPath([flag, value]));
+    }
+
+    [Theory]
+    [InlineData("--dataPath=/managed")]
+    [InlineData("-d=/managed")]
+    public void EqualsSeparatedValueIsExtracted(string arg)
+    {
+        Assert.Equal("/managed", Program.ResolveDataPath([arg]));
+    }
+
+    [Fact]
+    public void MissingFlagReturnsNull()
+    {
+        Assert.Null(Program.ResolveDataPath(["--other", "x"]));
+    }
+
+    [Fact]
+    public void FlagWithoutValueReturnsNull()
+    {
+        Assert.Null(Program.ResolveDataPath(["--dataPath"]));
+    }
+
+    [Fact]
+    public void FirstMatchWins()
+    {
+        Assert.Equal("/first", Program.ResolveDataPath(["--dataPath=/first", "--dataPath", "/second"]));
+    }
+}

--- a/Optimum.Launcher/Program.cs
+++ b/Optimum.Launcher/Program.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
+[assembly: InternalsVisibleTo("Optimum.Launcher.Tests")]
+
 namespace Optimum.Launcher;
 
 /// <summary>
@@ -612,14 +614,25 @@ public static class Program
     }
 
     /// <summary>
-    /// Extracts --dataPath from CLI args (same as VS does).
+    /// Extracts --dataPath from CLI args, matching the forms the game itself
+    /// accepts through CommandLineParser: "--dataPath VALUE" and
+    /// "--dataPath=VALUE", plus the "-d" convenience forms. Returns null when
+    /// absent so the caller falls back to datapath.cfg and then the install
+    /// directory.
     /// </summary>
-    private static string? ResolveDataPath(string[] args)
+    internal static string? ResolveDataPath(string[] args)
     {
-        for (int i = 0; i < args.Length - 1; i++)
+        for (int i = 0; i < args.Length; i++)
         {
-            if (args[i] is "--dataPath" or "-d")
-                return args[i + 1];
+            string arg = args[i];
+            if (arg is "--dataPath" or "-d")
+            {
+                return i + 1 < args.Length ? args[i + 1] : null;
+            }
+            if (arg.StartsWith("--dataPath=", StringComparison.Ordinal))
+                return arg["--dataPath=".Length..];
+            if (arg.StartsWith("-d=", StringComparison.Ordinal))
+                return arg["-d=".Length..];
         }
 
         var configPath = Path.Combine(AppContext.BaseDirectory, "datapath.cfg");

--- a/Optimum.Tests/installer-release-coverage-tests.cs
+++ b/Optimum.Tests/installer-release-coverage-tests.cs
@@ -230,6 +230,106 @@ public class InstallerReleaseCoverageTests
     }
 
     [Fact]
+    public void RuntimeDonorPatchGatesValidateEveryMandatoryProjectBeforeApplying()
+    {
+        string bash = Read("scripts/runtime-donor-patch-gate.sh");
+        string bashPreparation = Read("scripts/prepare-runtime-donors.sh");
+        string powershell = Read("scripts/prepare-runtime-donors.ps1");
+
+        Assert.Contains("runtime-donor-patch-gate.sh", bashPreparation);
+        Assert.Contains("runtime_projects=(VSEssentials VSSurvivalMod)", bash);
+        Assert.Contains("runtime_patch_failures=()", bash);
+        Assert.Contains("Runtime donor compatibility gate failed:", bash);
+        Assert.Contains("exit 1", bash);
+        int bashFailureGate = bash.IndexOf("Runtime donor compatibility gate failed:", StringComparison.Ordinal);
+        int bashApply = bash.IndexOf(
+            "git -C \"$repo_root\" apply \\",
+            bashFailureGate,
+            StringComparison.Ordinal);
+        Assert.True(bashFailureGate >= 0, "Bash donor failure gate is missing");
+        Assert.True(bashApply > bashFailureGate, "Bash applies a patch before its compatibility gate");
+
+        Assert.Contains("$runtimeProjects = @('VSEssentials', 'VSSurvivalMod')", powershell);
+        Assert.Contains("$runtimePatchFailures = @()", powershell);
+        Assert.Contains("$patchExitCode = $LASTEXITCODE", powershell);
+        Assert.Contains("2>&1 |", powershell);
+        Assert.Contains("git apply --check failed without diagnostic output.", powershell);
+        Assert.Contains("Runtime donor compatibility gate failed:", powershell);
+        int powershellFailureGate = powershell.IndexOf("Runtime donor compatibility gate failed:", StringComparison.Ordinal);
+        int powershellApply = powershell.IndexOf(
+            "git -C $repoRoot apply",
+            powershellFailureGate,
+            StringComparison.Ordinal);
+        Assert.True(powershellFailureGate >= 0, "PowerShell donor failure gate is missing");
+        Assert.True(powershellApply > powershellFailureGate, "PowerShell applies a patch before its compatibility gate");
+    }
+
+    [Fact]
+    public void BashRuntimeDonorPatchGateRejectsPartialCompatibility()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        string gate = PatchReader.FindRepositoryFile("scripts/runtime-donor-patch-gate.sh");
+        DirectoryInfo tempDirectory = Directory.CreateTempSubdirectory("optimum-runtime-gate-");
+
+        try
+        {
+            string runtimeRoot = Path.Combine(tempDirectory.FullName, "runtime");
+            string patchesRoot = Path.Combine(tempDirectory.FullName, "patches", "runtime");
+            string goodTarget = Path.Combine(runtimeRoot, "VSEssentials", "Good.cs");
+            Directory.CreateDirectory(Path.GetDirectoryName(goodTarget)!);
+            Directory.CreateDirectory(Path.Combine(patchesRoot, "VSEssentials"));
+            Directory.CreateDirectory(Path.Combine(patchesRoot, "VSSurvivalMod"));
+            File.WriteAllText(goodTarget, "old\n");
+            File.WriteAllText(
+                Path.Combine(patchesRoot, "VSEssentials", "Good.cs.patch"),
+                """
+                diff --git a/VSEssentials/Good.cs b/VSEssentials/Good.cs
+                --- a/VSEssentials/Good.cs
+                +++ b/VSEssentials/Good.cs
+                @@ -1 +1 @@
+                -old
+                +new
+                """.Replace("                ", ""));
+            File.WriteAllText(
+                Path.Combine(patchesRoot, "VSSurvivalMod", "Missing.cs.patch"),
+                """
+                diff --git a/VSSurvivalMod/Missing.cs b/VSSurvivalMod/Missing.cs
+                --- a/VSSurvivalMod/Missing.cs
+                +++ b/VSSurvivalMod/Missing.cs
+                @@ -1 +1 @@
+                -missing
+                +new
+                """.Replace("                ", ""));
+
+            ProcessStartInfo startInfo = new("bash")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            startInfo.ArgumentList.Add(gate);
+            startInfo.ArgumentList.Add(tempDirectory.FullName);
+            startInfo.ArgumentList.Add("runtime");
+            using Process process = Process.Start(startInfo)!;
+            string output = process.StandardOutput.ReadToEnd();
+            string error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            Assert.NotEqual(0, process.ExitCode);
+            Assert.Contains("Runtime donor compatibility gate failed", output + error);
+            Assert.Equal("old\n", File.ReadAllText(goodTarget));
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void RuntimePatchesHaveASeparateExactDonorPipeline()
     {
         string bootstrap = Read("scripts/bootstrap.sh");

--- a/README.md
+++ b/README.md
@@ -118,6 +118,30 @@ make build
 
 Open the .dmg and drag Optimum.app to Applications. Requires .NET 10 SDK, bash, python3, git, curl, perl.
 
+## Settings
+
+Optimum persists its runtime settings to `ModConfig/optimum.json` inside your
+Vintage Story data path. The file is created with defaults on first run.
+The `.optimum/` directory under the same data path holds launcher state
+(donor assemblies, the patched-assembly cache, and the shader compatibility
+report), not user settings.
+
+The data path depends on the platform:
+
+| Platform | Data path |
+|---|---|
+| Windows | `%APPDATA%\VintagestoryData` |
+| Linux | `~/.config/VintagestoryData` |
+| macOS | `~/Library/Application Support/VintagestoryData` |
+
+Older macOS installs may still have `~/.config/VintagestoryData`; the game
+moves that folder to the new location on first run.
+
+The client reads the file once at startup, so a full restart is required
+after editing it. When troubleshooting world-generation problems, the four
+relevant keys are `ChunkReadPoolEnabled`, `ChunkReadPoolWorkers`,
+`ChunkDeserializeParallel`, and `ChunkDeserializeParallelMinY`.
+
 ## Build
 
 ### Targeting a Vintage Story version

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -14,6 +14,13 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 
+# A GIT_DIR inherited from the calling environment (some tools and shell rc
+# files export it) overrides repository discovery for every git call below:
+# the clone succeeds, then the very next `git -C <clone> config` dies with
+# "fatal: not in a git directory". Drop it, along with its siblings, so this
+# script only ever talks to repositories it names explicitly.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 usage() {
   cat <<'EOF'
 Usage: scripts/bootstrap.sh [--version VERSION] [--client-archive PATH] [--refresh]
@@ -455,6 +462,12 @@ if [[ -f "$forks_file" ]]; then
       rm -rf "$base"
       echo "Cloning $name at $ref"
       git -c core.autocrlf=false -c core.eol=lf clone --quiet "$url" "$base"
+      if [[ ! -d "$base/.git" ]]; then
+        echo "Cloning $name succeeded but left no repository at $base" >&2
+        echo "Check the URL in forks.json and your git environment (GIT_DIR," >&2
+        echo "GIT_WORK_TREE), then retry." >&2
+        exit 1
+      fi
       git -C "$base" config core.autocrlf false
       git -C "$base" config core.eol lf
       git -C "$base" checkout --quiet "$ref"

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -226,9 +226,9 @@ install_optimum() {
     # Step 5: Remove vanilla launcher.
     rm -f "$install_dir/Vintagestory" 2>/dev/null
 
-    # Step 6: Create .optimum config dir.
+    # Step 6: Create the launcher state dir. Runtime settings live in
+    # ModConfig/optimum.json under the VS data path, not here.
     mkdir -p "$install_dir/.optimum"
-    [[ -f "$install_dir/.optimum/optimum.json" ]] || echo '{}' > "$install_dir/.optimum/optimum.json"
     echo "$OPTIMUM_VERSION" > "$install_dir/.optimum/version"
 
     cat > "$install_dir/run-optimum.sh" <<'LAUNCHER'

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -333,9 +333,13 @@ fi
 # 6. Rebrand: rename launcher, repoint run.sh, swap icon, brand .desktop
 # ============================================================================
 
+# Keep the vanilla-named binary too: managers like StoryForge hardcode
+# 'vintagestory' when launching the game, and both names load the same
+# patched Vintagestory.dll through the embedded entry name, so either
+# entrypoint runs Optimum.
 if [[ -f "$STAGE_DIR/Vintagestory" ]]; then
-    mv "$STAGE_DIR/Vintagestory" "$STAGE_DIR/Optimum"
-    chmod +x "$STAGE_DIR/Optimum"
+    cp -f "$STAGE_DIR/Vintagestory" "$STAGE_DIR/Optimum"
+    chmod +x "$STAGE_DIR/Vintagestory" "$STAGE_DIR/Optimum"
 else
     echo "Warning: launcher 'Vintagestory' not found in archive." >&2
 fi

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -229,9 +229,12 @@ if [[ -n "$BAD_SHADERS" ]]; then
 fi
 
 # 6. Rebrand: rename launcher, swap icon, rewrite Info.plist.
+# Keep the vanilla-named binary too so managers that hardcode 'vintagestory'
+# still reach Optimum; CFBundleExecutable stays Optimum. Both copies load the
+# same patched Vintagestory.dll through the embedded entry name.
 if [[ -f "$APP_DIR/Vintagestory" ]]; then
-    mv "$APP_DIR/Vintagestory" "$APP_DIR/Optimum"
-    chmod +x "$APP_DIR/Optimum"
+    cp -f "$APP_DIR/Vintagestory" "$APP_DIR/Optimum"
+    chmod +x "$APP_DIR/Vintagestory" "$APP_DIR/Optimum"
 else
     echo "Warning: launcher 'Vintagestory' not found in bundle." >&2
 fi

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -126,6 +126,12 @@ try {
     foreach ($launcherFile in @('Optimum.exe', 'Optimum.dll', 'Optimum.deps.json', 'Optimum.runtimeconfig.json')) {
         Copy-Item -Force (Join-Path $launcherOut $launcherFile) $stageDir
     }
+    # Managers that launch the game executable by its vanilla name
+    # (StoryForge launches Vintagestory.exe directly) must get the Optimum
+    # launcher, not a vanilla start. The apphost embeds the managed entry
+    # name (Optimum.dll), so a byte copy still loads and runs the launcher;
+    # Optimum.runtimeconfig.json and Optimum.dll are already staged above.
+    Copy-Item -Force (Join-Path $launcherOut 'Optimum.exe') (Join-Path $stageDir 'Vintagestory.exe')
     # Native assets for the launcher's patch-progress splash screen (OpenTK's
     # GLFW, SkiaSharp's text renderer). .NET's default native resolver looks
     # for these under runtimes/<rid>/native/ relative to the app base

--- a/scripts/prepare-runtime-donors.ps1
+++ b/scripts/prepare-runtime-donors.ps1
@@ -305,19 +305,34 @@ Exclude-CompileItems $survivalProject @(
 Resolve-ProjectReferences $essentialsProject
 Resolve-ProjectReferences $survivalProject
 
-foreach ($project in @('VSEssentials', 'VSSurvivalMod')) {
+$runtimeProjects = @('VSEssentials', 'VSSurvivalMod')
+$runtimePatchFailures = @()
+foreach ($project in $runtimeProjects) {
     $patchRoot = Join-Path $repoRoot "patches/runtime/$project"
     Get-ChildItem -Path $patchRoot -Filter '*.patch' -Recurse -File |
         Sort-Object FullName |
         ForEach-Object {
             $patchPath = $_.FullName
-            Invoke-NativeStep {
-                & git -C $repoRoot apply --check --directory='.build/runtime-donors' --whitespace=nowarn $patchPath *> $null
+            $patchOutput = Invoke-NativeStep {
+                & git -C $repoRoot apply --check --directory='.build/runtime-donors' --whitespace=nowarn $patchPath 2>&1 |
+                    Out-String
             }
-            if ($LASTEXITCODE -ne 0) {
-                throw "Runtime donor unavailable: $project requires a patch refresh for $($_.Name)."
+            $patchExitCode = $LASTEXITCODE
+            if ($patchExitCode -ne 0) {
+                $details = ([string]$patchOutput).Trim()
+                if (-not $details) {
+                    $details = 'git apply --check failed without diagnostic output.'
+                }
+                $runtimePatchFailures += "$project requires a patch refresh for $($_.Name): $details"
             }
         }
+}
+if ($runtimePatchFailures.Count -gt 0) {
+    throw "Runtime donor compatibility gate failed:`n  $($runtimePatchFailures -join "`n  ")"
+}
+
+foreach ($project in $runtimeProjects) {
+    $patchRoot = Join-Path $repoRoot "patches/runtime/$project"
     Get-ChildItem -Path $patchRoot -Filter '*.patch' -Recurse -File |
         Sort-Object FullName |
         ForEach-Object {

--- a/scripts/prepare-runtime-donors.sh
+++ b/scripts/prepare-runtime-donors.sh
@@ -4,15 +4,6 @@ if (set -o pipefail 2>/dev/null); then
     set -o pipefail
 fi
 
-# sort -z is GNU coreutils; macOS sort lacks it. Fall back to plain sort
-# (patch filenames have no embedded newlines, so null-delimiting is
-# cosmetic and not required for correctness).
-if echo | sort -z 2>/dev/null; then
-    sort_z() { sort -z; }
-else
-    sort_z() { sort; }
-fi
-
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 vanilla_dir="${VANILLA_DIR:-$repo_root/.vanilla/win-x64/vintagestory}"
@@ -330,30 +321,8 @@ resolve_references() {
 resolve_references "$essentials_project"
 resolve_references "$survival_project"
 
-eligible_projects=()
-for project in VSEssentials VSSurvivalMod; do
-    project_ready=1
-    while IFS= read -r -d '' patch; do
-        if ! git -C "$repo_root" apply --check \
-            --directory=".build/runtime-donors" \
-            --whitespace=nowarn \
-            "$patch"; then
-            echo "Runtime donor unavailable: $project requires a patch refresh for $(basename "$patch")." >&2
-            project_ready=0
-            break
-        fi
-    done < <(find "$repo_root/patches/runtime/$project" -name '*.patch' -print0 | sort_z)
-
-    if [[ "$project_ready" == "1" ]]; then
-        while IFS= read -r -d '' patch; do
-            git -C "$repo_root" apply \
-                --directory=".build/runtime-donors" \
-                --whitespace=nowarn \
-                "$patch"
-        done < <(find "$repo_root/patches/runtime/$project" -name '*.patch' -print0 | sort_z)
-        eligible_projects+=("$project")
-    fi
-done
+"$repo_root/scripts/runtime-donor-patch-gate.sh" "$repo_root" ".build/runtime-donors"
+eligible_projects=(VSEssentials VSSurvivalMod)
 
 # Optimum-owned new types are source overlays, not decompiled game source.
 if [[ " ${eligible_projects[*]} " == *" VSEssentials "* ]]; then

--- a/scripts/runtime-donor-patch-gate.sh
+++ b/scripts/runtime-donor-patch-gate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -eu
+if (set -o pipefail 2>/dev/null); then
+    set -o pipefail
+fi
+
+if [[ "$#" -ne 2 ]]; then
+    echo "Usage: $0 <repository-root> <runtime-root-relative-to-repository>" >&2
+    exit 2
+fi
+
+repo_root="$1"
+runtime_root="$2"
+patch_root="$repo_root/patches/runtime"
+
+if echo | sort -z 2>/dev/null; then
+    sort_z() { sort -z; }
+else
+    sort_z() { sort; }
+fi
+
+runtime_projects=(VSEssentials VSSurvivalMod)
+runtime_patch_failures=()
+for project in "${runtime_projects[@]}"; do
+    while IFS= read -r -d '' patch; do
+        if ! patch_error="$(git -C "$repo_root" apply --check \
+            --directory="$runtime_root" \
+            --whitespace=nowarn \
+            "$patch" 2>&1)"; then
+            printf '%s\n' "$patch_error" >&2
+            runtime_patch_failures+=("$project requires a patch refresh for $(basename "$patch")")
+        fi
+    done < <(find "$patch_root/$project" -name '*.patch' -print0 | sort_z)
+done
+
+if [[ "${#runtime_patch_failures[@]}" != "0" ]]; then
+    echo "Runtime donor compatibility gate failed:" >&2
+    printf '  %s\n' "${runtime_patch_failures[@]}" >&2
+    exit 1
+fi
+
+for project in "${runtime_projects[@]}"; do
+    while IFS= read -r -d '' patch; do
+        git -C "$repo_root" apply \
+            --directory="$runtime_root" \
+            --whitespace=nowarn \
+            "$patch"
+    done < <(find "$patch_root/$project" -name '*.patch' -print0 | sort_z)
+done
+
+printf 'Runtime donor patches applied for:'
+printf ' %s' "${runtime_projects[@]}"
+printf '\n'


### PR DESCRIPTION
## Summary

Promotes `dev` to `main`, carrying 10 commits `main` did not have:

- #38: document the settings file path
- #39: stop inheriting `GIT_DIR` during bootstrap clones
- fix: parse `--dataPath=value` in the launcher
- fix: launch Optimum when a manager runs `Vintagestory.exe`
- fix: keep the vanilla launcher name in Linux and macOS packages
- #40: fix the StoryForge data path
- #42: fail closed on partial runtime donors (addresses #27)

## Test plan

- [x] #42 was verified directly on real Windows PowerShell 5.1 and a dispatched `windows-latest` CI run before merging into `dev`: bootstrap, build, check-patches, and package all passed. Full evidence in the private workspace record.
- [x] Confirmed `main...dev` was exactly these 10 commits ahead before opening this PR.
