### PR TITLE
fix(render): keep clouds valid after resize

### DIFF
--- a/Optimum.Launcher.Tests/DataPathArgumentTests.cs
+++ b/Optimum.Launcher.Tests/DataPathArgumentTests.cs
@@ -56,6 +56,41 @@ public sealed class DataPathArgumentTests
     }
 
     [Fact]
+    public void MissingConfiguredDataPathIsIgnored()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "optimum-data-path-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string configPath = Path.Combine(root, "datapath.cfg");
+        File.WriteAllText(configPath, Path.Combine(root, "missing"));
+        try
+        {
+            Assert.Null(Program.ResolveConfiguredDataPath(configPath));
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExistingConfiguredDataPathIsAccepted()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "optimum-data-path-tests", Guid.NewGuid().ToString("N"));
+        string dataPath = Path.Combine(root, "data");
+        Directory.CreateDirectory(dataPath);
+        string configPath = Path.Combine(root, "datapath.cfg");
+        File.WriteAllText(configPath, $"  {dataPath}  ");
+        try
+        {
+            Assert.Equal(dataPath, Program.ResolveConfiguredDataPath(configPath));
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void DefaultDataPathMatchesPackagedGamePath()
     {
         string gameDir = Path.Combine(Path.GetTempPath(), "optimum-data-path-tests", Guid.NewGuid().ToString("N"));

--- a/Optimum.Launcher.Tests/DataPathArgumentTests.cs
+++ b/Optimum.Launcher.Tests/DataPathArgumentTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using Optimum.Launcher;
 using Xunit;
 
@@ -37,5 +39,40 @@ public sealed class DataPathArgumentTests
     public void FirstMatchWins()
     {
         Assert.Equal("/first", Program.ResolveDataPath(["--dataPath=/first", "--dataPath", "/second"]));
+    }
+
+    [Fact]
+    public void DefaultDataPathUsesInstallDirectoryForDevelopmentBuilds()
+    {
+        string gameDir = Path.Combine(Path.GetTempPath(), "optimum-data-path-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Assert.Equal(gameDir, Program.ResolveDefaultDataPath(gameDir));
+        }
+        finally
+        {
+            if (Directory.Exists(gameDir)) Directory.Delete(gameDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DefaultDataPathMatchesPackagedGamePath()
+    {
+        string gameDir = Path.Combine(Path.GetTempPath(), "optimum-data-path-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(gameDir, "assets"));
+        try
+        {
+            string applicationData = Environment.GetFolderPath(
+                Environment.SpecialFolder.ApplicationData,
+                Environment.SpecialFolderOption.DoNotVerify);
+            string expected = string.IsNullOrEmpty(applicationData)
+                ? gameDir
+                : Path.Combine(applicationData, "VintagestoryData");
+            Assert.Equal(expected, Program.ResolveDefaultDataPath(gameDir));
+        }
+        finally
+        {
+            if (Directory.Exists(gameDir)) Directory.Delete(gameDir, recursive: true);
+        }
     }
 }

--- a/Optimum.Launcher.Tests/ShaderCompatibilityScannerTests.cs
+++ b/Optimum.Launcher.Tests/ShaderCompatibilityScannerTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.Text;
+using Optimum.Launcher;
+using Xunit;
+
+namespace Optimum.Launcher.Tests;
+
+public sealed class ShaderCompatibilityScannerTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "optimum-shader-compatibility-tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void IgnoresOptimumBuiltInModsAtTheGameDirectory()
+    {
+        string modsPath = Path.Combine(_root, "game", "Mods");
+        Directory.CreateDirectory(modsPath);
+        WriteHookAssembly(Path.Combine(modsPath, "VSEssentials.dll"));
+        WriteHookAssembly(Path.Combine(modsPath, "VSSurvivalMod.dll"));
+
+        ShaderCompatibilityReport report = ShaderCompatibilityScanner.Scan(_root, Path.Combine(_root, "game"), "test");
+
+        Assert.Empty(report.Sources);
+        Assert.DoesNotContain("Oit", report.DisabledFeatures);
+        Assert.DoesNotContain("EntityLightBatch", report.DisabledFeatures);
+        Assert.DoesNotContain("EntityShaderStateCache", report.DisabledFeatures);
+    }
+
+    [Fact]
+    public void ScansSameNamedExternalModsFromTheDataDirectory()
+    {
+        string dataPath = Path.Combine(_root, "data");
+        string modsPath = Path.Combine(dataPath, "Mods");
+        Directory.CreateDirectory(modsPath);
+        WriteHookAssembly(Path.Combine(modsPath, "VSEssentials.dll"));
+        WriteHookAssembly(Path.Combine(modsPath, "VSSurvivalMod.dll"));
+        WriteHookAssembly(Path.Combine(modsPath, "CustomHook.dll"));
+
+        ShaderCompatibilityReport report = ShaderCompatibilityScanner.Scan(
+            dataPath,
+            Path.Combine(_root, "game"),
+            "test");
+
+        Assert.Equal(3, report.Sources.Count);
+        Assert.Contains(report.Sources, source => source.Name == "VSEssentials");
+        Assert.Contains(report.Sources, source => source.Name == "VSSurvivalMod");
+        Assert.Contains(report.Sources, source => source.Name == "CustomHook");
+        Assert.Contains("Oit", report.DisabledFeatures);
+        Assert.Contains("EntityLightBatch", report.DisabledFeatures);
+    }
+
+    private static void WriteHookAssembly(string path)
+    {
+        File.WriteAllBytes(path, Encoding.UTF8.GetBytes(
+            "ShaderRegistry LoadShaderProgram Harmony RegisterRenderer"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+}

--- a/Optimum.Launcher/Program.cs
+++ b/Optimum.Launcher/Program.cs
@@ -637,13 +637,20 @@ public static class Program
 
         var configPath = Path.Combine(AppContext.BaseDirectory, "datapath.cfg");
         if (File.Exists(configPath))
-        {
-            var configuredPath = File.ReadAllText(configPath).Trim();
-            if (configuredPath.Length > 0)
-                return configuredPath;
-        }
+            return ResolveConfiguredDataPath(configPath);
 
         return null;
+    }
+
+    internal static string? ResolveConfiguredDataPath(string configPath)
+    {
+        if (!File.Exists(configPath))
+            return null;
+
+        string configuredPath = File.ReadAllText(configPath).Trim();
+        return configuredPath.Length > 0 && Directory.Exists(configuredPath)
+            ? configuredPath
+            : null;
     }
 
     /// <summary>

--- a/Optimum.Launcher/Program.cs
+++ b/Optimum.Launcher/Program.cs
@@ -58,8 +58,9 @@ public static class Program
         var gameDir = AppContext.BaseDirectory;
 
         // Resolve cache directory: {dataPath}/.optimum/cache/
-        // Use the game's own data path resolution if possible, otherwise local.
-        var dataPath = ResolveDataPath(args) ?? gameDir;
+        // Mirror GamePaths.DataPath when no explicit path was supplied so the
+        // launcher report and the runtime configuration use the same root.
+        var dataPath = ResolveDataPath(args) ?? ResolveDefaultDataPath(gameDir);
         Logger.Init(dataPath);
 
         ShaderCompatibilityReport shaderCompatibility;
@@ -617,8 +618,7 @@ public static class Program
     /// Extracts --dataPath from CLI args, matching the forms the game itself
     /// accepts through CommandLineParser: "--dataPath VALUE" and
     /// "--dataPath=VALUE", plus the "-d" convenience forms. Returns null when
-    /// absent so the caller falls back to datapath.cfg and then the install
-    /// directory.
+    /// no explicit path or datapath.cfg entry exists.
     /// </summary>
     internal static string? ResolveDataPath(string[] args)
     {
@@ -644,6 +644,25 @@ public static class Program
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Mirrors the production and development branches of GamePaths.DataPath.
+    /// The launcher runs beside the game's assets in a packaged installation.
+    /// </summary>
+    internal static string ResolveDefaultDataPath(string gameDir)
+    {
+        // GamePaths uses AppDomain.CurrentDomain.BaseDirectory in the same
+        // no-assets development mode.
+        if (!Directory.Exists(Path.Combine(gameDir, "assets")))
+            return gameDir;
+
+        string applicationData = Environment.GetFolderPath(
+            Environment.SpecialFolder.ApplicationData,
+            Environment.SpecialFolderOption.DoNotVerify);
+        return string.IsNullOrEmpty(applicationData)
+            ? gameDir
+            : Path.Combine(applicationData, "VintagestoryData");
     }
 
     private static bool HasArgument(string[] args, string expected)

--- a/Optimum.Launcher/ShaderCompatibilityScanner.cs
+++ b/Optimum.Launcher/ShaderCompatibilityScanner.cs
@@ -36,6 +36,12 @@ public static class ShaderCompatibilityScanner
         ("enumrenderstage", "RenderHook")
     ];
 
+    private static readonly string[] OptimumBuiltInMods =
+    [
+        "VSEssentials.dll",
+        "VSSurvivalMod.dll"
+    ];
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
@@ -64,7 +70,7 @@ public static class ShaderCompatibilityScanner
                 {
                     try
                     {
-                        ScanSource(entry, dataPath, report);
+                        ScanSource(entry, dataPath, gameDir, report);
                     }
                     catch (Exception ex) when (IsRecoverable(ex))
                     {
@@ -126,9 +132,9 @@ public static class ShaderCompatibilityScanner
         return report;
     }
 
-    private static void ScanSource(string sourcePath, string dataPath, ShaderCompatibilityReport report)
+    private static void ScanSource(string sourcePath, string dataPath, string gameDir, ShaderCompatibilityReport report)
     {
-        if (IsOptimumSource(sourcePath)) return;
+        if (IsOptimumSource(sourcePath, gameDir)) return;
 
         var source = new ShaderModSource
         {
@@ -335,11 +341,30 @@ public static class ShaderCompatibilityScanner
         "assets/game/shaders/chunkopaque.vsh" or "assets/game/shaders/final.fsh" or
         "assets/game/shaders/godrays.fsh" or "assets/game/shaders/cloudvolumetric.fsh";
 
-    private static bool IsOptimumSource(string path)
+    private static bool IsOptimumSource(string path, string gameDir)
     {
         string name = Path.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        return name.Equals("Optimum", StringComparison.OrdinalIgnoreCase) ||
-            name.StartsWith("Optimum-", StringComparison.OrdinalIgnoreCase);
+        if (name.Equals("Optimum", StringComparison.OrdinalIgnoreCase) ||
+            name.StartsWith("Optimum-", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        try
+        {
+            string fullPath = Path.GetFullPath(path);
+            string builtInModsPath = Path.GetFullPath(Path.Combine(gameDir, "Mods"));
+            return OptimumBuiltInMods.Any(mod =>
+                string.Equals(fullPath, Path.Combine(builtInModsPath, mod), StringComparison.OrdinalIgnoreCase));
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
     }
 
     private static string? NormalizeShaderPath(string path)

--- a/Optimum.Tests/oit-framebuffer-rebuild-coverage-tests.cs
+++ b/Optimum.Tests/oit-framebuffer-rebuild-coverage-tests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Xunit;
 
@@ -16,7 +17,27 @@ public class OitFramebufferRebuildCoverageTests
 
         // The rebuild condition must detect when the framebuffer instance changed
         // (after RebuildFrameBuffers replaces the list entry with a new object).
-        Assert.Contains("transparentfb != capi.Render.FrameBuffers[1]", source);
+        Assert.Contains("transparentfb != currentTransparentfb", source);
+    }
+
+    [Fact]
+    public void OitRebuildComparesPreviousFramebufferToCurrentBeforeReplacingIt()
+    {
+        string source = Read("build/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs");
+
+        int currentFramebuffer = source.IndexOf(
+            "FrameBufferRef currentTransparentfb = capi.Render.FrameBuffers[1]",
+            StringComparison.Ordinal);
+        int identityCheck = source.IndexOf(
+            "transparentfb != currentTransparentfb",
+            StringComparison.Ordinal);
+        int methodEnd = source.IndexOf("private void freeResources", currentFramebuffer, StringComparison.Ordinal);
+
+        Assert.True(currentFramebuffer >= 0, "The current transparent framebuffer must be captured without replacing the previous reference.");
+        Assert.True(identityCheck > currentFramebuffer, "The OIT rebuild must compare the previous reference with the current framebuffer.");
+        Assert.True(methodEnd > currentFramebuffer, "The OIT render method must have a recognizable boundary.");
+        string renderMethod = source.Substring(currentFramebuffer, methodEnd - currentFramebuffer);
+        Assert.DoesNotContain("transparentfb = capi.Render.FrameBuffers[1]", renderMethod);
     }
 
     [Fact]

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs.patch
@@ -2,7 +2,7 @@ diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs 
 index bba43f6..8414cd7 100644
 --- a/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs
 +++ b/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderOITLayers.cs
-@@ -18,45 +18,94 @@ public class SystemRenderOITLayers : ClientSystem
+@@ -18,45 +18,95 @@ public class SystemRenderOITLayers : ClientSystem
  		public int RenderRange => 1;
  
  		public BeforeOIT(ICoreClientAPI capi)
@@ -40,8 +40,8 @@ index bba43f6..8414cd7 100644
 +					SystemRenderOITLayers.DisableOptimumOit(capi, "render resources are unavailable");
 +					return;
 +				}
-+				transparentfb = capi.Render.FrameBuffers[1];
-+				if (transparentfb == null || transparentfb.Disposed)
++				FrameBufferRef currentTransparentfb = capi.Render.FrameBuffers[1];
++				if (currentTransparentfb == null || currentTransparentfb.Disposed)
 +				{
 +					SystemRenderOITLayers.DisableOptimumOit(capi, "transparent framebuffer is disposed");
 +					return;
@@ -63,8 +63,9 @@ index bba43f6..8414cd7 100644
 +				programByName.Uniform("liquidDepth", 4);
 +				programByName.Stop();
 +				if (currentActiveShader != null && !currentActiveShader.Disposed) currentActiveShader.Use();
-+				if (revealTextureId == 0 || transparentfb.Disposed || transparentfb != capi.Render.FrameBuffers[1])
++				if (revealTextureId == 0 || transparentfb == null || transparentfb.Disposed || transparentfb != currentTransparentfb)
 +				{
++					transparentfb = currentTransparentfb;
 +					rebuild();
 +					if (revealTextureId == 0 || accumTextureId == 0)
 +					{


### PR DESCRIPTION
Addresses #26

### Cause

The shader compatibility scanner read both dataPath/Mods and gameDir/Mods. It treated Optimum-owned VSEssentials.dll and VSSurvivalMod.dll as external render hooks, which disabled OIT and related features on a clean install. When no path argument existed, the launcher could also write the report using a fallback that did not mirror the runtime data-path rules.

The original resize reproduction exposed a second bug in the OIT path. BeforeOIT replaced its stored transparent framebuffer with the current list entry before comparing identities, so a framebuffer replacement could never trigger an OIT texture rebuild. After a fullscreen transition, cloud rendering used stale OIT resources and produced black regions.

### Change

- Trust the two built-in assemblies only at their exact gameDir/Mods paths.
- Continue scanning same-named assemblies under dataPath/Mods and unrelated assemblies in either mod root.
- Mirror the production and development branches of GamePaths.DataPath when no explicit path exists.
- Ignore a datapath.cfg entry when its directory is missing, matching the client-side config reader.
- Capture the current transparent framebuffer before comparing it with the previous reference, then rebuild OIT textures after a replacement.
- Add launcher tests for built-in donors, same-named external assemblies, third-party hooks, configured paths, and default data paths.
- Add OIT coverage for the framebuffer identity comparison and replacement order.

### Validation

- dotnet test Optimum.Launcher.Tests/Optimum.Launcher.Tests.csproj -c Release --no-restore: 19 passed.
- OIT coverage suite: 8 passed.
- make check: passed.
- make build: passed with 0 warnings and 0 errors.
- make check-patches: 68 patches applied, 48 Cecil patches, 0 pending, unavailable, or conflicting patches.
- make check-shaders: passed.
- make check-compat: passed with 0 cast divergences and 17 allowlisted skips.
- make test: 645 passed, 34 skipped, and 5 existing coverage assertions failed in unchanged installer, FSR, and entity-render source checks.
- Authenticated live validation used a fresh creative world through the local data path. The pre-fix client showed black cloud regions after F11 changed the window to 1920x1080. The fixed client kept the clouds clear through the same transition and reported no startup issues.
