### PR TITLE
fix(patcher): tolerate stale debug symbols

### DIFF
--- a/Optimum.Patcher/AssemblyReader.cs
+++ b/Optimum.Patcher/AssemblyReader.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Optimum.Patcher;
+
+/// <summary>
+/// Reads patch inputs while treating debug symbols as optional metadata.
+/// </summary>
+internal static class AssemblyReader
+{
+    public static AssemblyDefinition Read(
+        string path,
+        ReaderParameters parameters,
+        out bool symbolsLoaded)
+    {
+        symbolsLoaded = false;
+
+        if (!parameters.ReadSymbols)
+        {
+            return AssemblyDefinition.ReadAssembly(path, parameters);
+        }
+
+        try
+        {
+            AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(path, parameters);
+            symbolsLoaded = true;
+            return assembly;
+        }
+        catch (SymbolsNotFoundException ex)
+        {
+            return ReadWithoutSymbols(path, parameters, ex);
+        }
+        catch (SymbolsNotMatchingException ex)
+        {
+            return ReadWithoutSymbols(path, parameters, ex);
+        }
+    }
+
+    private static AssemblyDefinition ReadWithoutSymbols(
+        string path,
+        ReaderParameters parameters,
+        Exception symbolError)
+    {
+        Console.Error.WriteLine(
+            $"  WARNING: Ignoring symbols for {Path.GetFileName(path)}: {symbolError.Message}");
+        parameters.ReadSymbols = false;
+        return AssemblyDefinition.ReadAssembly(path, parameters);
+    }
+}

--- a/Optimum.Patcher/AssemblyWriter.cs
+++ b/Optimum.Patcher/AssemblyWriter.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using Mono.Cecil;
+
+namespace Optimum.Patcher;
+
+/// <summary>
+/// Writes patched assemblies without leaving stale debug-symbol sidecars.
+/// </summary>
+internal static class AssemblyWriter
+{
+    public static void Write(
+        AssemblyDefinition assembly,
+        string outputPath,
+        bool writeSymbols)
+    {
+        if (!writeSymbols)
+        {
+            File.Delete(Path.ChangeExtension(outputPath, ".pdb"));
+        }
+
+        assembly.Write(outputPath, new WriterParameters { WriteSymbols = writeSymbols });
+    }
+}

--- a/Optimum.Patcher/ILPatcher.cs
+++ b/Optimum.Patcher/ILPatcher.cs
@@ -269,7 +269,7 @@ public static class ILPatcher
             return -1;
         }
 
-        vanillaAsm.Write(outputPath, new WriterParameters { WriteSymbols = preserveSymbols });
+        AssemblyWriter.Write(vanillaAsm, outputPath, preserveSymbols);
         if (preserveSymbols)
         {
             Console.WriteLine($"  Wrote matching symbols: {Path.ChangeExtension(outputPath, ".pdb")}");

--- a/Optimum.Patcher/ILPatcher.cs
+++ b/Optimum.Patcher/ILPatcher.cs
@@ -104,7 +104,7 @@ public static class ILPatcher
             ReadSymbols = false
         };
 
-        using var vanillaAsm = AssemblyDefinition.ReadAssembly(vanillaPath, vanillaReaderParams);
+        using var vanillaAsm = AssemblyReader.Read(vanillaPath, vanillaReaderParams, out preserveSymbols);
         using var compiledAsm = AssemblyDefinition.ReadAssembly(compiledPath, compiledReaderParams);
 
         int injectedInterfaces = interfacesToInject == null

--- a/Optimum.Patcher/api-patcher.cs
+++ b/Optimum.Patcher/api-patcher.cs
@@ -142,7 +142,7 @@ public static class ApiPatcher
         }
 
         Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputPath))!);
-        vanilla.Write(outputPath, new WriterParameters { WriteSymbols = preserveSymbols });
+        AssemblyWriter.Write(vanilla, outputPath, preserveSymbols);
         if (preserveSymbols)
         {
             Console.WriteLine($"  Wrote matching symbols: {Path.ChangeExtension(outputPath, ".pdb")}");

--- a/Optimum.Patcher/api-patcher.cs
+++ b/Optimum.Patcher/api-patcher.cs
@@ -43,7 +43,7 @@ public static class ApiPatcher
             ReadSymbols = false,
         };
 
-        using var vanilla = AssemblyDefinition.ReadAssembly(vanillaPath, vanillaReaderParameters);
+        using var vanilla = AssemblyReader.Read(vanillaPath, vanillaReaderParameters, out preserveSymbols);
         using var contracts = AssemblyDefinition.ReadAssembly(contractsPath, contractsReaderParameters);
 
         var bridge = contracts.MainModule.GetType("Vintagestory.API.Config.OptimumApiBridge")

--- a/Optimum.Tests/pdb-symbol-fallback-tests.cs
+++ b/Optimum.Tests/pdb-symbol-fallback-tests.cs
@@ -117,6 +117,34 @@ public sealed class PdbSymbolFallbackTests
         }
     }
 
+    [Fact]
+    public void DiscardedSymbolsRemoveAStaleOutputSidecar()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"optimum-symbol-output-{Guid.NewGuid():N}");
+        string outputPath = Path.Combine(root, "output.dll");
+        string outputPdbPath = Path.ChangeExtension(outputPath, ".pdb");
+
+        try
+        {
+            Directory.CreateDirectory(root);
+            File.WriteAllText(outputPdbPath, "stale symbols");
+
+            using AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition("Optimum.SymbolOutputFixture", new Version(1, 0, 0, 0)),
+                "Optimum.SymbolOutputFixture",
+                ModuleKind.Dll);
+
+            AssemblyWriter.Write(assembly, outputPath, writeSymbols: false);
+
+            Assert.True(File.Exists(outputPath));
+            Assert.False(File.Exists(outputPdbPath));
+        }
+        finally
+        {
+            DeleteFixture(root);
+        }
+    }
+
     private static void CopyOutputAssembly(string assemblyPath, string? pdbName)
     {
         string outputDirectory = Path.GetDirectoryName(typeof(PdbSymbolFallbackTests).Assembly.Location)!;

--- a/Optimum.Tests/pdb-symbol-fallback-tests.cs
+++ b/Optimum.Tests/pdb-symbol-fallback-tests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using Mono.Cecil;
+using Optimum.Patcher;
+using Xunit;
+
+namespace Optimum.Tests;
+
+public sealed class PdbSymbolFallbackTests
+{
+    [Fact]
+    public void MatchingSymbolsArePreserved()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"optimum-symbol-match-{Guid.NewGuid():N}");
+        string assemblyPath = Path.Combine(root, "assembly.dll");
+
+        try
+        {
+            Directory.CreateDirectory(root);
+            CopyOutputAssembly(assemblyPath, "Optimum.Api.Contracts.pdb");
+
+            var parameters = new ReaderParameters { ReadSymbols = true };
+            using AssemblyDefinition assembly = AssemblyReader.Read(
+                assemblyPath,
+                parameters,
+                out bool symbolsLoaded);
+
+            Assert.True(symbolsLoaded);
+            Assert.Equal("Optimum.Api.Contracts", assembly.Name.Name);
+        }
+        finally
+        {
+            DeleteFixture(root);
+        }
+    }
+
+    [Fact]
+    public void MismatchedSymbolsAreIgnoredAndAssemblyStillLoads()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"optimum-symbol-test-{Guid.NewGuid():N}");
+        string firstPath = Path.Combine(root, "first.dll");
+
+        try
+        {
+            Directory.CreateDirectory(root);
+            CopyOutputAssembly(firstPath, "Optimum.GameContent.pdb");
+
+            var parameters = new ReaderParameters { ReadSymbols = true };
+            using AssemblyDefinition assembly = AssemblyReader.Read(
+                firstPath,
+                parameters,
+                out bool symbolsLoaded);
+
+            Assert.False(symbolsLoaded);
+            Assert.Equal("Optimum.Api.Contracts", assembly.Name.Name);
+        }
+        finally
+        {
+            DeleteFixture(root);
+        }
+    }
+
+    [Fact]
+    public void MissingSymbolsDoNotEnableSymbolLoading()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"optimum-symbol-missing-{Guid.NewGuid():N}");
+        string assemblyPath = Path.Combine(root, "assembly.dll");
+
+        try
+        {
+            Directory.CreateDirectory(root);
+            CopyOutputAssembly(assemblyPath, pdbName: null);
+
+            var parameters = new ReaderParameters { ReadSymbols = true };
+            using AssemblyDefinition assembly = AssemblyReader.Read(
+                assemblyPath,
+                parameters,
+                out bool symbolsLoaded);
+
+            Assert.False(symbolsLoaded);
+            Assert.False(parameters.ReadSymbols);
+            Assert.Equal("Optimum.Api.Contracts", assembly.Name.Name);
+        }
+        finally
+        {
+            DeleteFixture(root);
+        }
+    }
+
+    [Fact]
+    public void CorruptSymbolsStillFailTheRead()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"optimum-symbol-corrupt-{Guid.NewGuid():N}");
+        string assemblyPath = Path.Combine(root, "assembly.dll");
+
+        try
+        {
+            Directory.CreateDirectory(root);
+            CopyOutputAssembly(assemblyPath, pdbName: null);
+            File.WriteAllText(Path.ChangeExtension(assemblyPath, ".pdb"), "not a portable PDB");
+
+            var parameters = new ReaderParameters { ReadSymbols = true };
+            Exception? error = Record.Exception(() =>
+            {
+                using AssemblyDefinition assembly = AssemblyReader.Read(
+                    assemblyPath,
+                    parameters,
+                    out _);
+            });
+
+            Assert.NotNull(error);
+            Assert.True(parameters.ReadSymbols);
+        }
+        finally
+        {
+            DeleteFixture(root);
+        }
+    }
+
+    private static void CopyOutputAssembly(string assemblyPath, string? pdbName)
+    {
+        string outputDirectory = Path.GetDirectoryName(typeof(PdbSymbolFallbackTests).Assembly.Location)!;
+        File.Copy(Path.Combine(outputDirectory, "Optimum.Api.Contracts.dll"), assemblyPath);
+        if (pdbName is not null)
+        {
+            File.Copy(Path.Combine(outputDirectory, pdbName), Path.ChangeExtension(assemblyPath, ".pdb"));
+        }
+    }
+
+    private static void DeleteFixture(string root)
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Addresses #46

## Summary

The patcher now treats missing or mismatched PDB files as optional metadata. It retries the vanilla assembly read without symbols, logs the reason, and continues patching. Matching symbols remain enabled and are written to the output as before.

Both the engine and API patchers use the shared reader. When symbols are discarded, the writer removes any stale output PDB before writing the patched DLL. Five tests cover matching, missing, mismatched, corrupt, and stale-output PDB files. Corrupt symbols still fail the read instead of being silently ignored.

## Root cause

The previous code enabled Mono.Cecil symbol loading whenever a PDB existed beside the vanilla DLL. A stale PDB then raised `SymbolsNotMatchingException` during `ReadSymbols` before patch validation could start.

This PR addresses that reported failure class. The issue does not include a complete log, platform, or game installation context, so confirmation in the reporter's environment remains pending.

## Validation

- Focused PDB regression suite: 5 passed.
- Pristine mismatched-PDB engine patch: 126 of 126 required methods patched, with no output PDB written and a pre-existing output PDB removed.
- `make check`: passed.
- `make check-patches`: 68 patches applied, 48 Cecil patches, zero pending, unavailable, or conflicting patches.
- `make check-shaders`: passed.
- `make check-compat`: passed with zero cast divergences.
- `make build`: passed with zero warnings and zero errors.
- `Optimum.Launcher.Tests`: 19 passed.
- `make test`: 650 passed, 34 skipped, and five existing coverage assertions failed outside this diff.

The change affects optional debug metadata only and does not change patched runtime IL.