### PR TITLE
fix(server): close chunk readers before save reload

### DIFF
--- a/Optimum.Patcher/ILHook.cs
+++ b/Optimum.Patcher/ILHook.cs
@@ -157,10 +157,99 @@ public static class ILHook
         return true;
     }
 
+    /// <summary>
+    /// Inserts a parameterless instance void hook immediately before exactly one
+    /// matching call in the target method. Unlike <see cref="InsertBeforeCall"/>,
+    /// this preserves the target call's existing stack (the call is void and has
+    /// no return value to carry through).
+    /// </summary>
+    public static bool InsertInstanceVoidCallBefore(
+        AssemblyDefinition vanillaAsm,
+        string typeName, string methodName, int paramCount,
+        string hookMethodName, string targetCallName,
+        string targetDeclaringType,
+        IReadOnlyList<string> targetParameterTypes,
+        string targetReturnType,
+        bool targetHasThis,
+        bool targetExplicitThis,
+        MethodCallingConvention targetCallingConvention,
+        int targetGenericArity)
+    {
+        var type = vanillaAsm.MainModule.GetType(typeName);
+        if (type == null) { Console.Error.WriteLine($"  HOOK SKIP: type not found {typeName}"); return false; }
+
+        var method = MethodSignature.FindUnique(type, methodName, paramCount);
+        if (method == null) { Console.Error.WriteLine($"  HOOK SKIP: method not found {typeName}::{methodName}"); return false; }
+        method.DebugInformation.SequencePoints.Clear();
+        method.DebugInformation.Scope = null;
+
+        var hookMethod = MethodSignature.FindUnique(type, hookMethodName);
+        if (hookMethod == null) { Console.Error.WriteLine($"  HOOK SKIP: hook method not found {typeName}::{hookMethodName}"); return false; }
+        if (!hookMethod.HasThis || hookMethod.Parameters.Count != 0 || hookMethod.ReturnType.FullName != "System.Void")
+        {
+            Console.Error.WriteLine($"  HOOK SKIP: {typeName}::{hookMethodName} must be a parameterless instance void method");
+            return false;
+        }
+
+        var targetCalls = method.Body.Instructions
+            .Where(i => (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt) &&
+                        i.Operand is MethodReference mr &&
+                        MethodSignature.Matches(
+                            mr,
+                            targetDeclaringType,
+                            targetCallName,
+                            targetParameterTypes,
+                            targetReturnType,
+                            targetHasThis,
+                            targetExplicitThis,
+                            targetCallingConvention,
+                            targetGenericArity))
+            .ToList();
+
+        if (targetCalls.Count != 1)
+        {
+            Console.Error.WriteLine(
+                $"  HOOK SKIP: expected exactly one call to {targetCallName} in " +
+                $"{typeName}::{methodName}, found {targetCalls.Count}");
+            return false;
+        }
+
+        var targetCall = targetCalls[0];
+        if (AlreadyCallsHookBefore(targetCall, hookMethod))
+        {
+            Console.WriteLine($"  HOOK EXISTS: {typeName}::{methodName} before {targetCallName} → {hookMethodName}");
+            return true;
+        }
+
+        var il = method.Body.GetILProcessor();
+        il.InsertBefore(targetCall, il.Create(OpCodes.Ldarg_0));
+        il.InsertBefore(targetCall, il.Create(OpCodes.Call, hookMethod));
+        method.Body.MaxStackSize = Math.Max(method.Body.MaxStackSize, method.Body.MaxStackSize + 1);
+
+        Console.WriteLine($"  HOOKED: {typeName}::{methodName} before {targetCallName} → {hookMethodName}");
+        return true;
+    }
+
     private static bool AlreadyCallsHook(Instruction? start, MethodDefinition hookMethod)
     {
         Instruction? cursor = start;
         for (int i = 0; i < 6 && cursor != null; i++, cursor = cursor.Next)
+        {
+            if ((cursor.OpCode == OpCodes.Call || cursor.OpCode == OpCodes.Callvirt) &&
+                cursor.Operand is MethodReference method &&
+                MethodSignature.Matches(hookMethod, method))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool AlreadyCallsHookBefore(Instruction target, MethodDefinition hookMethod)
+    {
+        Instruction? cursor = target.Previous;
+        for (int i = 0; i < 6 && cursor != null; i++, cursor = cursor.Previous)
         {
             if ((cursor.OpCode == OpCodes.Call || cursor.OpCode == OpCodes.Callvirt) &&
                 cursor.Operand is MethodReference method &&

--- a/Optimum.Patcher/ILPatcher.cs
+++ b/Optimum.Patcher/ILPatcher.cs
@@ -199,20 +199,35 @@ public static class ILPatcher
         {
             foreach (var hook in hooks)
             {
-                bool inserted = ILHook.InsertBeforeCall(
-                    vanillaAsm,
-                    hook.TypeFullName,
-                    hook.MethodName,
-                    hook.ParamCount,
-                    hook.HookMethod,
-                    hook.TargetCall,
-                    hook.TargetDeclaringType,
-                    hook.TargetParameterTypes,
-                    hook.TargetReturnType,
-                    hook.TargetHasThis,
-                    hook.TargetExplicitThis,
-                    hook.TargetCallingConvention,
-                    hook.TargetGenericArity);
+                bool inserted = hook.InsertBeforeTarget
+                    ? ILHook.InsertInstanceVoidCallBefore(
+                        vanillaAsm,
+                        hook.TypeFullName,
+                        hook.MethodName,
+                        hook.ParamCount,
+                        hook.HookMethod,
+                        hook.TargetCall,
+                        hook.TargetDeclaringType,
+                        hook.TargetParameterTypes,
+                        hook.TargetReturnType,
+                        hook.TargetHasThis,
+                        hook.TargetExplicitThis,
+                        hook.TargetCallingConvention,
+                        hook.TargetGenericArity)
+                    : ILHook.InsertBeforeCall(
+                        vanillaAsm,
+                        hook.TypeFullName,
+                        hook.MethodName,
+                        hook.ParamCount,
+                        hook.HookMethod,
+                        hook.TargetCall,
+                        hook.TargetDeclaringType,
+                        hook.TargetParameterTypes,
+                        hook.TargetReturnType,
+                        hook.TargetHasThis,
+                        hook.TargetExplicitThis,
+                        hook.TargetCallingConvention,
+                        hook.TargetGenericArity);
                 if (!inserted && !hook.Optional)
                 {
                     throw new InvalidOperationException($"Required IL hook was not applied: {hook}");
@@ -886,7 +901,8 @@ public record HookTarget(
     bool TargetExplicitThis,
     MethodCallingConvention TargetCallingConvention,
     int TargetGenericArity,
-    bool Optional = false)
+    bool Optional = false,
+    bool InsertBeforeTarget = false)
 {
     public override string ToString() =>
         $"{TypeFullName}::{MethodName} -> {HookMethod} before {TargetCall}";

--- a/Optimum.Patcher/Program.cs
+++ b/Optimum.Patcher/Program.cs
@@ -305,6 +305,7 @@ var membersToInject = new Dictionary<string, List<string>>
     {
         "optimumSaveBatch",
         "TryStartOptimumChunkReadPool",
+        "DisposeOptimumChunkReadPool",
     },
     ["Vintagestory.Server.ServerSystemBlockSimulation"] = new()
     {
@@ -586,9 +587,10 @@ var targets = new List<MethodTarget>
     new("Vintagestory.Server.ServerSystemLoadAndSaveGame", "SaveAllDirtyMapChunks", 1),
     new("Vintagestory.Server.ServerSystemLoadAndSaveGame", "SaveAllDirtyLoadedChunks", 2),
     new("Vintagestory.Server.ServerSystemLoadAndSaveGame", "SaveAllDirtyGeneratingChunks", 1),
-    // OnSeperateThreadShutDown is deliberately not a target: its only change is
-    // disposing optimumReadPool, but the pre-existing body also references the
-    // class's shared <>c (SaveGameWorld's cached delegate) - see "Gap B" above.
+    // OnSeperateThreadShutDown is deliberately not a target: its pre-existing
+    // body references the class's shared <>c (SaveGameWorld's cached delegate).
+    // DisposeOptimumChunkReadPool is injected and called by an IL hook immediately
+    // before the vanilla GameDatabase.Dispose call instead.
     new("Vintagestory.Server.ServerSystemSendChunks", "sendAndEnqueueChunks", 1),
     new("Vintagestory.Server.ServerSystemBlockSimulation", "GetUpdateInterval", 0),
     new("Vintagestory.Server.ServerSystemBlockSimulation", "OnSeparateThreadTick", 0),
@@ -637,6 +639,23 @@ int total = ILPatcher.PatchWithInjection(
             TargetExplicitThis: false,
             TargetCallingConvention: MethodCallingConvention.Default,
             TargetGenericArity: 0),
+        // The shutdown method cannot be transplanted because its pre-existing
+        // body references the shared <>c nested type. Clear and dispose the
+        // read-only SQLite pool immediately before the vanilla database closes.
+        new(
+            "Vintagestory.Server.ServerSystemLoadAndSaveGame",
+            "OnSeperateThreadShutDown",
+            0,
+            "DisposeOptimumChunkReadPool",
+            "Dispose",
+            TargetDeclaringType: "Vintagestory.Common.GameDatabase",
+            TargetParameterTypes: [],
+            TargetReturnType: "System.Void",
+            TargetHasThis: true,
+            TargetExplicitThis: false,
+            TargetCallingConvention: MethodCallingConvention.Default,
+            TargetGenericArity: 0,
+            InsertBeforeTarget: true),
     },
     fieldsToRetype: fieldsToRetype);
 

--- a/Optimum.Tests/chunk-read-pool-lifecycle-tests.cs
+++ b/Optimum.Tests/chunk-read-pool-lifecycle-tests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.IO;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Optimum.Patcher;
+using Xunit;
+
+namespace Optimum.Tests;
+
+public sealed class ChunkReadPoolLifecycleTests
+{
+    [Fact]
+    public void ShutdownHookInsertsThePoolDisposeBeforeTheDatabaseDispose()
+    {
+        using AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("OptimumLifecycleFixture", new Version(1, 0, 0, 0)),
+            "OptimumLifecycleFixture",
+            ModuleKind.Dll);
+        ModuleDefinition module = assembly.MainModule;
+
+        var gameDatabase = new TypeDefinition(
+            "Vintagestory.Common",
+            "GameDatabase",
+            TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(gameDatabase);
+
+        var databaseDispose = new MethodDefinition(
+            "Dispose",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            module.TypeSystem.Void);
+        gameDatabase.Methods.Add(databaseDispose);
+        databaseDispose.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+
+        var loadSave = new TypeDefinition(
+            "Vintagestory.Server",
+            "ServerSystemLoadAndSaveGame",
+            TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(loadSave);
+
+        var databaseField = new FieldDefinition(
+            "gameDatabase",
+            FieldAttributes.Private,
+            gameDatabase);
+        loadSave.Fields.Add(databaseField);
+
+        var poolDispose = new MethodDefinition(
+            "DisposeOptimumChunkReadPool",
+            MethodAttributes.Private | MethodAttributes.HideBySig,
+            module.TypeSystem.Void);
+        loadSave.Methods.Add(poolDispose);
+        poolDispose.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+
+        var shutdown = new MethodDefinition(
+            "OnSeperateThreadShutDown",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            module.TypeSystem.Void);
+        loadSave.Methods.Add(shutdown);
+        var processor = shutdown.Body.GetILProcessor();
+        processor.Append(Instruction.Create(OpCodes.Ldarg_0));
+        processor.Append(Instruction.Create(OpCodes.Ldfld, databaseField));
+        processor.Append(Instruction.Create(OpCodes.Callvirt, databaseDispose));
+        processor.Append(Instruction.Create(OpCodes.Ret));
+
+        bool inserted = ILHook.InsertInstanceVoidCallBefore(
+            assembly,
+            "Vintagestory.Server.ServerSystemLoadAndSaveGame",
+            "OnSeperateThreadShutDown",
+            0,
+            "DisposeOptimumChunkReadPool",
+            "Dispose",
+            "Vintagestory.Common.GameDatabase",
+            Array.Empty<string>(),
+            "System.Void",
+            targetHasThis: true,
+            targetExplicitThis: false,
+            MethodCallingConvention.Default,
+            targetGenericArity: 0);
+
+        Assert.True(inserted);
+
+        int databaseDisposeIndex = shutdown.Body.Instructions
+            .Select((instruction, index) => (instruction, index))
+            .Single(item => item.instruction.Operand is MethodReference method && method.Name == "Dispose")
+            .index;
+
+        Assert.Equal(OpCodes.Ldarg_0, shutdown.Body.Instructions[databaseDisposeIndex - 2].OpCode);
+        Assert.Equal(OpCodes.Call, shutdown.Body.Instructions[databaseDisposeIndex - 1].OpCode);
+        Assert.Equal("DisposeOptimumChunkReadPool", ((MethodReference)shutdown.Body.Instructions[databaseDisposeIndex - 1].Operand!).Name);
+        Assert.Equal(OpCodes.Callvirt, shutdown.Body.Instructions[databaseDisposeIndex].OpCode);
+
+        // The patcher should be safe if a caller retries the same hook against
+        // an already-modified module.
+        Assert.True(ILHook.InsertInstanceVoidCallBefore(
+            assembly,
+            "Vintagestory.Server.ServerSystemLoadAndSaveGame",
+            "OnSeperateThreadShutDown",
+            0,
+            "DisposeOptimumChunkReadPool",
+            "Dispose",
+            "Vintagestory.Common.GameDatabase",
+            Array.Empty<string>(),
+            "System.Void",
+            targetHasThis: true,
+            targetExplicitThis: false,
+            MethodCallingConvention.Default,
+            targetGenericArity: 0));
+
+        Assert.Equal(1, shutdown.Body.Instructions.Count(instruction =>
+            instruction.Operand is MethodReference method && method.Name == "DisposeOptimumChunkReadPool"));
+    }
+
+    [Fact]
+    public void OptimumPatchOwnsPoolShutdownBeforeClosingTheSaveDatabase()
+    {
+        string patch = PatchReader.ReadPatch(
+            "patches/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs.patch");
+        string program = File.ReadAllText(PatchReader.FindRepositoryFile("Optimum.Patcher/Program.cs"));
+        string ilHook = File.ReadAllText(PatchReader.FindRepositoryFile("Optimum.Patcher/ILHook.cs"));
+
+        Assert.Contains("DisposeOptimumChunkReadPool();", patch);
+        Assert.Contains("chunkthread.optimumReadPool = null;", patch);
+        Assert.Contains("pool?.Dispose();", patch);
+        Assert.True(
+            patch.IndexOf("chunkthread.optimumReadPool = null;", StringComparison.Ordinal) <
+            patch.IndexOf("pool?.Dispose();", StringComparison.Ordinal));
+        Assert.Contains("\"DisposeOptimumChunkReadPool\"", program);
+        Assert.Contains("InsertBeforeTarget: true", program);
+        Assert.Contains("InsertInstanceVoidCallBefore", ilHook);
+        Assert.Contains("expected exactly one call", ilHook);
+    }
+}

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs
-index 43dace8..0c2708a 100644
+index 43dace8..90acd17 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemLoadAndSaveGame.cs
 @@ -28,10 +28,17 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
@@ -35,20 +35,19 @@ index 43dace8..0c2708a 100644
  		{
  			server.ModEventManager.RegisterOnServerRunPhase(EnumServerRunPhase.RunGame, OnRestoreFromBuildLog);
  		}
-@@ -207,10 +218,12 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+@@ -207,10 +218,11 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
  		}
  	}
  
  	public override void OnSeperateThreadShutDown()
  	{
-+		try { chunkthread.optimumReadPool?.Dispose(); } catch { }
-+		chunkthread.optimumReadPool = null;
++		DisposeOptimumChunkReadPool();
  		chunkthread.gameDatabase.Dispose();
  	}
  
  	public void OnWorldBeingSaved()
  	{
-@@ -398,11 +411,13 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+@@ -398,11 +410,13 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
  	}
  
  	private int SaveAllDirtyMapRegions(FastMemoryStream ms)
@@ -63,7 +62,7 @@ index 43dace8..0c2708a 100644
  			if (loadedMapRegion.Value.DirtyForSaving)
  			{
  				loadedMapRegion.Value.DirtyForSaving = false;
-@@ -419,11 +434,13 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+@@ -419,11 +433,13 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
  	}
  
  	private int SaveAllDirtyMapChunks(FastMemoryStream ms)
@@ -78,7 +77,7 @@ index 43dace8..0c2708a 100644
  			if (loadedMapChunk.Value.DirtyForSaving)
  			{
  				loadedMapChunk.Value.DirtyForSaving = false;
-@@ -446,11 +463,13 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+@@ -446,11 +462,13 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
  	}
  
  	internal int SaveAllDirtyLoadedChunks(bool isSaveLater, FastMemoryStream ms)
@@ -93,7 +92,7 @@ index 43dace8..0c2708a 100644
  			PopulateChunksCopy();
  		}
  		foreach (KeyValuePair<long, ServerChunk> item in chunksCopy)
-@@ -504,11 +523,13 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+@@ -504,11 +522,13 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
  	internal int SaveAllDirtyGeneratingChunks(FastMemoryStream ms)
  	{
  		int num = 0;
@@ -108,7 +107,7 @@ index 43dace8..0c2708a 100644
  			{
  				if (item.Chunks == null || item.Disposed || item.CurrentIncompletePass <= EnumWorldGenPass.Terrain)
  				{
-@@ -721,6 +742,31 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
+@@ -721,6 +741,45 @@ internal class ServerSystemLoadAndSaveGame : ServerSystem, IChunkProviderThread
  			list.Clear();
  		}
  		ServerMain.Logger.Notification($"Block restore: Total of {dictionary.Count} chunks and {num} block have been restored from the build log. {num2} Blocks already had a new Block at their position.");
@@ -136,6 +135,20 @@ index 43dace8..0c2708a 100644
 +		{
 +			ServerMain.Logger.Warning("[Optimum] Chunk read pool failed to start: {0}", ex.Message);
 +			chunkthread.optimumReadPool = null;
++		}
++	}
++
++	private void DisposeOptimumChunkReadPool()
++	{
++		OptimumChunkReadPool pool = chunkthread.optimumReadPool;
++		chunkthread.optimumReadPool = null;
++		try
++		{
++			pool?.Dispose();
++		}
++		catch (Exception ex)
++		{
++			ServerMain.Logger.Warning("[Optimum] Chunk read pool shutdown failed: {0}", ex.Message);
 +		}
 +	}
 +


### PR DESCRIPTION
## Summary

Addresses #25 by disposing Optimum\047s SQLite chunk-read pool before the vanilla `GameDatabase.Dispose()` call during separate-thread shutdown. The pool field is detached before active readers drain, so a subsequent save load does not inherit the previous world\047s open read handles.

The change adds a focused Cecil hook instead of transplanting the lambda-bearing shutdown method, and adds synthetic IL and patch-contract coverage for the lifecycle.

## Verification

- `make build` passed with zero warnings and zero errors.
- `make patch-il` applied 126 of 126 required methods and both hooks; ILSpy readback shows `DisposeOptimumChunkReadPool()` immediately before `gameDatabase.Dispose()`.
- `make check-patches`, `make check-compat`, `make check-shaders`, and `make check` passed.
- The focused lifecycle suite passed 2 tests.
- `Optimum.Launcher.Tests` passed 19 tests.
- `make test` passed 652 tests and skipped 34. Five existing coverage tests still fail in `InstallerPathNormalizationTests`, `FsrPipelineCoverageTests`, and `EntityRenderP0Tests`; none touches this change.
- A fresh temporary world reached `RunGame` and closed cleanly with no remaining `.vcdbs` handles after shutdown.

The exact same-process menu reload could not be completed because the local graphics-session input did not reliably reach the in-game menu. `make package-win` also requires a Windows client layout with `Vintagestory.exe`; the local cache is Linux. `innoextract 1.9` was tested separately and cannot parse the official 1.22.7 installer format 6.4.3.