### PR TITLE
fix(packaging): support Inno Setup 6.4.3 off-platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Requires (dev):       .NET 10 SDK, bash, python3, git, curl, perl.
 # Requires (packaging): tar, curl. Optional per target:
 #                         macOS .dmg on Linux -> cmake + mkisofs/genisoimage
-#                         Windows package off-Windows -> pwsh + innoextract
+#                         Windows package off-Windows -> pwsh + innoextract >= 1.11
 # Run `make check` to see exactly what your host is missing.
 # Windows: use Git Bash, WSL, or adapt to PowerShell.
 #
@@ -197,5 +197,5 @@ package-appimage: build ## Package Linux x64 as AppImage (single executable)
 package-macos: build ## Package macOS (.dmg/.app); ARCH=arm64 or x64
 	bash scripts/package-macos.sh --arch $(or $(ARCH),arm64) --version $(VERSION)
 
-package-win: build ## Package Windows x64 (folder + zip); needs innoextract off-Windows
-	pwsh scripts/package.ps1 -Zip -Version $(VERSION)
+package-win: build ## Package Windows x64 (folder + zip); needs innoextract >= 1.11 off-Windows
+	pwsh scripts/package.ps1 -Zip -Version $(VERSION) $(if $(CLIENT_ARCHIVE),-ClientArchive "$(CLIENT_ARCHIVE)")

--- a/Makefile
+++ b/Makefile
@@ -197,5 +197,5 @@ package-appimage: build ## Package Linux x64 as AppImage (single executable)
 package-macos: build ## Package macOS (.dmg/.app); ARCH=arm64 or x64
 	bash scripts/package-macos.sh --arch $(or $(ARCH),arm64) --version $(VERSION)
 
-package-win: build ## Package Windows x64 (folder + zip); needs innoextract >= 1.11 off-Windows
+package-win: build ## Package Windows x64 (folder + zip); needs innoextract >= 1.11 off-Windows without package-client cache
 	pwsh scripts/package.ps1 -Zip -Version $(VERSION) $(if $(CLIENT_ARCHIVE),-ClientArchive "$(CLIENT_ARCHIVE)")

--- a/Optimum.Tests/installer-release-coverage-tests.cs
+++ b/Optimum.Tests/installer-release-coverage-tests.cs
@@ -164,9 +164,12 @@ public class InstallerReleaseCoverageTests
         Assert.Contains("version-*.txt", package);
         Assert.Contains("Installer extracted Vintage Story", package);
         Assert.Contains(".innoextract-stage-", package);
+        Assert.Contains(".vanilla/win-x64/package-client", package);
+        Assert.DoesNotContain("Move-Item -Path $winDir -Destination $backupDir", package);
         Assert.Contains("innoextract >= 1.11", makefile);
         Assert.Contains("ClientArchive", makefile);
         Assert.Contains("WIN_CACHE_DIR", packageAll);
+        Assert.Contains("package-client", packageAll);
         Assert.Contains("Vintagestory.exe", packageAll);
         Assert.Contains("innoextract >= 1.11", packageAll);
         Assert.Contains("command -v pwsh", packageAll);

--- a/Optimum.Tests/installer-release-coverage-tests.cs
+++ b/Optimum.Tests/installer-release-coverage-tests.cs
@@ -160,10 +160,16 @@ public class InstallerReleaseCoverageTests
         Assert.Contains("--extract", package);
         Assert.Contains("vs_install_win-x64_", package);
         Assert.Contains("cdn.vintagestory", package);
+        Assert.Contains("Get-WindowsClientVersion", package);
+        Assert.Contains("version-*.txt", package);
+        Assert.Contains("Installer extracted Vintage Story", package);
+        Assert.Contains(".innoextract-stage-", package);
         Assert.Contains("innoextract >= 1.11", makefile);
         Assert.Contains("ClientArchive", makefile);
-        Assert.Contains("vintagestory/Vintagestory.exe", packageAll);
+        Assert.Contains("WIN_CACHE_DIR", packageAll);
+        Assert.Contains("Vintagestory.exe", packageAll);
         Assert.Contains("innoextract >= 1.11", packageAll);
+        Assert.Contains("command -v pwsh", packageAll);
     }
 
     [Fact]

--- a/Optimum.Tests/installer-release-coverage-tests.cs
+++ b/Optimum.Tests/installer-release-coverage-tests.cs
@@ -156,6 +156,7 @@ public class InstallerReleaseCoverageTests
         Assert.DoesNotContain("cdn.vintagestory", installer);
         Assert.Contains("[string]$ClientArchive", package);
         Assert.Contains("innoextract >= 1.11", package);
+        Assert.Contains("A matching\npackage-client cache avoids the extractor", package);
         Assert.Contains("--info", package);
         Assert.Contains("--extract", package);
         Assert.Contains("vs_install_win-x64_", package);
@@ -170,6 +171,7 @@ public class InstallerReleaseCoverageTests
         Assert.Contains("ClientArchive", makefile);
         Assert.Contains("WIN_CACHE_DIR", packageAll);
         Assert.Contains("package-client", packageAll);
+        Assert.Contains("marker_version", packageAll);
         Assert.Contains("Vintagestory.exe", packageAll);
         Assert.Contains("innoextract >= 1.11", packageAll);
         Assert.Contains("command -v pwsh", packageAll);

--- a/Optimum.Tests/installer-release-coverage-tests.cs
+++ b/Optimum.Tests/installer-release-coverage-tests.cs
@@ -143,17 +143,27 @@ public class InstallerReleaseCoverageTests
     }
 
     [Fact]
-    public void WindowsInstallerRequiresAnExistingVintageStoryInstallation()
+    public void WindowsPackagingKeepsNativeInstallAndSupportsOffPlatformExtraction()
     {
         string installer = Read("scripts/install-windows.ps1");
         string package = Read("scripts/package.ps1");
+        string makefile = Read("Makefile");
+        string packageAll = Read("scripts/package-all.sh");
 
         Assert.Contains("Install Vintage Story $requiredVer before Optimum", installer);
         Assert.Contains("-VanillaDir $VsPath", installer);
         Assert.DoesNotContain("DownloadVs", installer);
         Assert.DoesNotContain("cdn.vintagestory", installer);
-        Assert.DoesNotContain("cdn.vintagestory", package);
-        Assert.DoesNotContain("innoextract", package);
+        Assert.Contains("[string]$ClientArchive", package);
+        Assert.Contains("innoextract >= 1.11", package);
+        Assert.Contains("--info", package);
+        Assert.Contains("--extract", package);
+        Assert.Contains("vs_install_win-x64_", package);
+        Assert.Contains("cdn.vintagestory", package);
+        Assert.Contains("innoextract >= 1.11", makefile);
+        Assert.Contains("ClientArchive", makefile);
+        Assert.Contains("vintagestory/Vintagestory.exe", packageAll);
+        Assert.Contains("innoextract >= 1.11", packageAll);
     }
 
     [Fact]

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Or call the scripts directly:
 ./scripts/package-all.sh --targets linux-x64,osx-arm64
 ```
 
-The Linux script renames the launcher to Optimum, repoints run.sh, swaps the window icon, and brands the .desktop entry. The macOS script assembles Optimum.app (renamed launcher, Icon.icns from the logo, rebranded Info.plist) and builds a drag-to-Applications .dmg. Off-Windows Windows packaging downloads the official `vs_install_win-x64_<version>.exe` into `.vanilla/archives/` and extracts it with `innoextract` 1.11 or newer; pass `-ClientArchive` to use a specific installer.
+The Linux script renames the launcher to Optimum, repoints run.sh, swaps the window icon, and brands the .desktop entry. The macOS script assembles Optimum.app (renamed launcher, Icon.icns from the logo, rebranded Info.plist) and builds a drag-to-Applications .dmg. Off-Windows Windows packaging downloads the official `vs_install_win-x64_<version>.exe` into `.vanilla/archives/` and extracts it with `innoextract` 1.11 or newer; pass `-ClientArchive` to supply the installer when no matching cache exists.
 
 ### Host prerequisites for packaging
 
@@ -217,7 +217,7 @@ Linux and macOS packaging runs with bash. No PowerShell required for those targe
 |---|---|---|---|
 | **linux-x64** | ✅ tar.gz / AppImage | ✅ tar.gz | ✅ tar.gz |
 | **osx-x64 / osx-arm64** | ✅ unsigned .dmg | ✅ signed .dmg (hdiutil) | ⚠️ .tar.gz fallback |
-| **win-x64** | ✅ WSL, or prefilled official cache | ⚠️ prefilled official cache | ✅ native |
+| **win-x64** | ✅ pwsh + innoextract >= 1.11 | ✅ pwsh + innoextract >= 1.11 | ✅ native |
 
 The .dmg files built on Linux are unsigned. macOS Gatekeeper shows a warning on first open; users right-click > Open to accept. For a notarizable .dmg, build on macOS with an Apple Developer certificate.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ make package              # all targets this host can produce
 make package-linux        # tar.gz
 make package-appimage     # single .AppImage executable
 make package-macos        # .dmg (ARCH=arm64 or x64)
-make package-win          # Windows zip (native Windows or WSL; cache works elsewhere)
+make package-win          # Windows zip (native Windows or off-platform with innoextract >= 1.11)
 ```
 
 Or call the scripts directly:
@@ -194,7 +194,7 @@ Or call the scripts directly:
 ./scripts/package-all.sh --targets linux-x64,osx-arm64
 ```
 
-The Linux script renames the launcher to Optimum, repoints run.sh, swaps the window icon, and brands the .desktop entry. The macOS script assembles Optimum.app (renamed launcher, Icon.icns from the logo, rebranded Info.plist) and builds a drag-to-Applications .dmg.
+The Linux script renames the launcher to Optimum, repoints run.sh, swaps the window icon, and brands the .desktop entry. The macOS script assembles Optimum.app (renamed launcher, Icon.icns from the logo, rebranded Info.plist) and builds a drag-to-Applications .dmg. Off-Windows Windows packaging downloads the official `vs_install_win-x64_<version>.exe` into `.vanilla/archives/` and extracts it with `innoextract` 1.11 or newer; pass `-ClientArchive` to use a specific installer.
 
 ### Host prerequisites for packaging
 
@@ -204,6 +204,7 @@ Beyond the build requirements (.NET 10 SDK, bash, git, curl, perl), packaging ne
 |---|---|---|
 | `appimagetool` | Builds .AppImage (downloaded to .tools/ on first use) | auto or `sudo apt install appimagetool` |
 | `pwsh` | Windows packaging off-platform (win-x64 target only) | [Install PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) |
+| `innoextract` >= 1.11 | Extracts the official Inno Setup 6.4.3 Windows client for off-platform packaging | [Current releases](https://github.com/crazy-max/innoextract/releases) (distro 1.9 is too old) |
 | Windows interoperability (`wslpath` + Windows PowerShell) | Runs the official Inno 6.4.3 installer into a disposable directory when bootstrapping win-x64 from WSL | included with WSL |
 | `mkisofs` / `genisoimage` | Creates hybrid HFS image for .dmg on Linux | `sudo apt install cdrtools` or `genisoimage` |
 | `cmake` + `git` | Build libdmg-hfsplus (compiled once into .tools/) | `sudo apt install cmake git` |

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Or call the scripts directly:
 ./scripts/package-all.sh --targets linux-x64,osx-arm64
 ```
 
-The Linux script renames the launcher to Optimum, repoints run.sh, swaps the window icon, and brands the .desktop entry. The macOS script assembles Optimum.app (renamed launcher, Icon.icns from the logo, rebranded Info.plist) and builds a drag-to-Applications .dmg. Off-Windows Windows packaging downloads the official `vs_install_win-x64_<version>.exe` into `.vanilla/archives/` and extracts it with `innoextract` 1.11 or newer; pass `-ClientArchive` to supply the installer when no matching cache exists.
+The Linux script renames the launcher to Optimum, repoints run.sh, swaps the window icon, and brands the .desktop entry. The macOS script assembles Optimum.app (renamed launcher, Icon.icns from the logo, rebranded Info.plist) and builds a drag-to-Applications .dmg. Off-Windows Windows packaging downloads the official `vs_install_win-x64_<version>.exe` into `.vanilla/archives/` and extracts it with `innoextract` 1.11 or newer. A matching `.vanilla/win-x64/vintagestory` cache is reused; otherwise extraction goes to `.vanilla/win-x64/package-client` so the bootstrap/decompile cache remains intact for `make run` and `make patch-il`. Pass `-ClientArchive` to supply the installer when no matching cache exists.
 
 ### Host prerequisites for packaging
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Or call the scripts directly:
 ./scripts/package-all.sh --targets linux-x64,osx-arm64
 ```
 
-The Linux script renames the launcher to Optimum, repoints run.sh, swaps the window icon, and brands the .desktop entry. The macOS script assembles Optimum.app (renamed launcher, Icon.icns from the logo, rebranded Info.plist) and builds a drag-to-Applications .dmg. Off-Windows Windows packaging downloads the official `vs_install_win-x64_<version>.exe` into `.vanilla/archives/` and extracts it with `innoextract` 1.11 or newer. A matching `.vanilla/win-x64/vintagestory` cache is reused; otherwise extraction goes to `.vanilla/win-x64/package-client` so the bootstrap/decompile cache remains intact for `make run` and `make patch-il`. Pass `-ClientArchive` to supply the installer when no matching cache exists.
+The Linux script renames the launcher to Optimum, repoints run.sh, swaps the window icon, and brands the .desktop entry. The macOS script assembles Optimum.app (renamed launcher, Icon.icns from the logo, rebranded Info.plist) and builds a drag-to-Applications .dmg. Off-Windows Windows packaging downloads the official `vs_install_win-x64_<version>.exe` into `.vanilla/archives/` and extracts it with `innoextract` 1.11 or newer when no matching `.vanilla/win-x64/package-client` cache exists. A matching package cache is reused without the extractor, and a fresh extraction leaves the bootstrap/decompile cache at `.vanilla/win-x64/vintagestory` intact for `make run` and `make patch-il`. Pass `-ClientArchive` to supply the installer when no matching package cache exists.
 
 ### Host prerequisites for packaging
 
@@ -204,7 +204,7 @@ Beyond the build requirements (.NET 10 SDK, bash, git, curl, perl), packaging ne
 |---|---|---|
 | `appimagetool` | Builds .AppImage (downloaded to .tools/ on first use) | auto or `sudo apt install appimagetool` |
 | `pwsh` | Windows packaging off-platform (win-x64 target only) | [Install PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) |
-| `innoextract` >= 1.11 | Extracts the official Inno Setup 6.4.3 Windows client for off-platform packaging | [Current releases](https://github.com/crazy-max/innoextract/releases) (distro 1.9 is too old) |
+| `innoextract` >= 1.11 | Extracts the official Inno Setup 6.4.3 Windows client when no matching package cache exists | [Current releases](https://github.com/crazy-max/innoextract/releases) (distro 1.9 is too old) |
 | Windows interoperability (`wslpath` + Windows PowerShell) | Runs the official Inno 6.4.3 installer into a disposable directory when bootstrapping win-x64 from WSL | included with WSL |
 | `mkisofs` / `genisoimage` | Creates hybrid HFS image for .dmg on Linux | `sudo apt install cdrtools` or `genisoimage` |
 | `cmake` + `git` | Build libdmg-hfsplus (compiled once into .tools/) | `sudo apt install cmake git` |
@@ -217,7 +217,7 @@ Linux and macOS packaging runs with bash. No PowerShell required for those targe
 |---|---|---|---|
 | **linux-x64** | ✅ tar.gz / AppImage | ✅ tar.gz | ✅ tar.gz |
 | **osx-x64 / osx-arm64** | ✅ unsigned .dmg | ✅ signed .dmg (hdiutil) | ⚠️ .tar.gz fallback |
-| **win-x64** | ✅ pwsh + innoextract >= 1.11 | ✅ pwsh + innoextract >= 1.11 | ✅ native |
+| **win-x64** | ✅ pwsh + innoextract >= 1.11, or package-client cache | ✅ pwsh + innoextract >= 1.11, or package-client cache | ✅ native |
 
 The .dmg files built on Linux are unsigned. macOS Gatekeeper shows a warning on first open; users right-click > Open to accept. For a notarizable .dmg, build on macOS with an Apple Developer certificate.
 

--- a/scripts/_hostcaps.ps1
+++ b/scripts/_hostcaps.ps1
@@ -49,18 +49,10 @@ function Test-InnoextractMinimumVersion {
 
 function Test-CachedWindowsClient {
     $repoRoot = Split-Path -Parent $PSScriptRoot
-    $clientDirs = @(
-        (Join-Path $repoRoot '.vanilla/win-x64/vintagestory'),
-        (Join-Path $repoRoot '.vanilla/win-x64/package-client')
-    )
-    foreach ($clientDir in $clientDirs) {
-        $marker = @(Get-ChildItem -Path (Join-Path $clientDir 'assets') -Filter 'version-*.txt' -File -ErrorAction SilentlyContinue |
-            Select-Object -First 1)
-        if ((Test-Path (Join-Path $clientDir 'Vintagestory.exe')) -and $marker.Count -gt 0) {
-            return $true
-        }
-    }
-    return $false
+    $clientDir = Join-Path $repoRoot '.vanilla/win-x64/package-client'
+    $marker = @(Get-ChildItem -Path (Join-Path $clientDir 'assets') -Filter 'version-*.txt' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1)
+    (Test-Path (Join-Path $clientDir 'Vintagestory.exe')) -and $marker.Count -gt 0
 }
 
 # Returns an array of capability objects: Target, Quality (Full/Degraded/Blocked), Note.

--- a/scripts/_hostcaps.ps1
+++ b/scripts/_hostcaps.ps1
@@ -20,6 +20,33 @@ function Get-HostOS {
 
 function Test-Cmd { param([string]$Name) [bool](Get-Command $Name -ErrorAction SilentlyContinue) }
 
+function Get-InnoextractVersion {
+    $command = Get-Command innoextract -ErrorAction SilentlyContinue
+    if (-not $command) { return $null }
+
+    $previousEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = @(& $command.Path --version 2>&1)
+        $exitCode = $LASTEXITCODE
+    } catch {
+        return $null
+    } finally {
+        $ErrorActionPreference = $previousEap
+    }
+    if ($exitCode -ne 0) { return $null }
+
+    $text = $output -join [Environment]::NewLine
+    if ($text -notmatch '(?im)^\s*innoextract\s+(\d+)\.(\d+)(?:\.(\d+))?') { return $null }
+    $patch = if ($Matches[3]) { [int]$Matches[3] } else { 0 }
+    return [Version]::new([int]$Matches[1], [int]$Matches[2], $patch)
+}
+
+function Test-InnoextractMinimumVersion {
+    $version = Get-InnoextractVersion
+    $version -and $version -ge [Version]'1.11'
+}
+
 function Test-CachedWindowsClient {
     $repoRoot = Split-Path -Parent $PSScriptRoot
     Test-Path (Join-Path $repoRoot '.vanilla/win-x64/vintagestory/Vintagestory.exe')
@@ -52,15 +79,18 @@ function Get-HostCaps {
     if ($os -eq 'Windows') {
         $caps += [pscustomobject]@{ Target='win-x64'; Quality='Full'; Note='native build + local vanilla client' }
     } else {
-        $hasExtract = (Test-Cmd innoextract)
+        $innoVersion = Get-InnoextractVersion
+        $hasExtract = $innoVersion -and $innoVersion -ge [Version]'1.11'
         $hasRid     = (Test-Cmd dotnet)   # cross-build the win-x64 apphost
         $hasCachedWinClient = Test-CachedWindowsClient
         if ($hasCachedWinClient -and $hasRid) {
             $caps += [pscustomobject]@{ Target='win-x64'; Quality='Degraded'; Note='cross-build Optimum.exe + cached Windows client' }
         } elseif ($hasExtract -and $hasRid) {
-            $caps += [pscustomobject]@{ Target='win-x64'; Quality='Degraded'; Note='cross-build Optimum.exe + innoextract vanilla installer' }
-        } elseif (-not $hasExtract) {
-            $caps += [pscustomobject]@{ Target='win-x64'; Quality='Blocked'; Note='need innoextract to unpack the Windows installer (vs_install_win-x64_*.exe)' }
+            $caps += [pscustomobject]@{ Target='win-x64'; Quality='Degraded'; Note="cross-build Optimum.exe + innoextract $innoVersion for the official Inno 6.4.3 installer" }
+        } elseif (-not $innoVersion) {
+            $caps += [pscustomobject]@{ Target='win-x64'; Quality='Blocked'; Note='need innoextract >= 1.11 to unpack the official Windows installer (vs_install_win-x64_*.exe)' }
+        } elseif ($innoVersion -lt [Version]'1.11') {
+            $caps += [pscustomobject]@{ Target='win-x64'; Quality='Blocked'; Note="innoextract $innoVersion is too old; need innoextract >= 1.11 for Inno Setup 6.4.3" }
         } else {
             $caps += [pscustomobject]@{ Target='win-x64'; Quality='Blocked'; Note='need dotnet to cross-build the win-x64 launcher' }
         }

--- a/scripts/_hostcaps.ps1
+++ b/scripts/_hostcaps.ps1
@@ -49,10 +49,18 @@ function Test-InnoextractMinimumVersion {
 
 function Test-CachedWindowsClient {
     $repoRoot = Split-Path -Parent $PSScriptRoot
-    $clientDir = Join-Path $repoRoot '.vanilla/win-x64/vintagestory'
-    $marker = @(Get-ChildItem -Path (Join-Path $clientDir 'assets') -Filter 'version-*.txt' -File -ErrorAction SilentlyContinue |
-        Select-Object -First 1)
-    (Test-Path (Join-Path $clientDir 'Vintagestory.exe')) -and $marker.Count -gt 0
+    $clientDirs = @(
+        (Join-Path $repoRoot '.vanilla/win-x64/vintagestory'),
+        (Join-Path $repoRoot '.vanilla/win-x64/package-client')
+    )
+    foreach ($clientDir in $clientDirs) {
+        $marker = @(Get-ChildItem -Path (Join-Path $clientDir 'assets') -Filter 'version-*.txt' -File -ErrorAction SilentlyContinue |
+            Select-Object -First 1)
+        if ((Test-Path (Join-Path $clientDir 'Vintagestory.exe')) -and $marker.Count -gt 0) {
+            return $true
+        }
+    }
+    return $false
 }
 
 # Returns an array of capability objects: Target, Quality (Full/Degraded/Blocked), Note.

--- a/scripts/_hostcaps.ps1
+++ b/scripts/_hostcaps.ps1
@@ -49,7 +49,10 @@ function Test-InnoextractMinimumVersion {
 
 function Test-CachedWindowsClient {
     $repoRoot = Split-Path -Parent $PSScriptRoot
-    Test-Path (Join-Path $repoRoot '.vanilla/win-x64/vintagestory/Vintagestory.exe')
+    $clientDir = Join-Path $repoRoot '.vanilla/win-x64/vintagestory'
+    $marker = @(Get-ChildItem -Path (Join-Path $clientDir 'assets') -Filter 'version-*.txt' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1)
+    (Test-Path (Join-Path $clientDir 'Vintagestory.exe')) -and $marker.Count -gt 0
 }
 
 # Returns an array of capability objects: Target, Quality (Full/Degraded/Blocked), Note.

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -40,7 +40,7 @@ for entry in "${checks[@]}"; do
       inno_version="$(innoextract --version 2>/dev/null | sed -n 's/^innoextract \([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1.\2/p' | head -n 1 || true)"
       inno_major="${inno_version%%.*}"
       inno_minor="${inno_version#*.}"
-      if [[ -z "$inno_version" || ! "$inno_major" =~ ^[0-9]+$ || ! "$inno_minor" =~ ^[0-9]+$ || ( "$inno_major" -eq 1 && "$inno_minor" -lt 11 ) ]]; then
+      if [[ -z "$inno_version" || ! "$inno_major" =~ ^[0-9]+$ || ! "$inno_minor" =~ ^[0-9]+$ || "$inno_major" -lt 1 || ( "$inno_major" -eq 1 && "$inno_minor" -lt 11 ) ]]; then
         printf '%-14s %s%-8s %s\n' "$name" "$(red OLD)" "" "$used"
         printf '               %s %s\n' "$(red '→ unsupported for Inno Setup 6.4.3.')" "$hint"
         missing_optional=$((missing_optional + 1))

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -26,7 +26,7 @@ checks=(
   "make|0|package-macos.ps1 (.dmg on Linux via libdmg-hfsplus)|apt-get install make"
   "cmake|0|package-macos.ps1 (.dmg on Linux via libdmg-hfsplus)|apt-get install cmake"
   "mkisofs|0|package-macos.ps1 (.dmg on Linux; genisoimage also works)|apt-get install cdrtools  (or genisoimage)"
-  "innoextract|0|package.ps1 (Windows package on Linux/macOS hosts)|apt-get install innoextract"
+  "innoextract|0|package.ps1 (off-platform Windows package; requires >= 1.11)|use a current release from https://github.com/crazy-max/innoextract/releases (distro 1.9 is too old)"
 )
 
 printf '%s\n\n' "$(yellow 'Optimum prerequisite check (report only - nothing is installed)')"
@@ -36,6 +36,19 @@ printf '%-14s %-10s %s\n' "----" "------" "-------"
 for entry in "${checks[@]}"; do
   IFS='|' read -r name required used hint <<< "$entry"
   if command -v "$name" >/dev/null 2>&1; then
+    if [[ "$name" == "innoextract" ]]; then
+      inno_version="$(innoextract --version 2>/dev/null | sed -n 's/^innoextract \([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1.\2/p' | head -n 1 || true)"
+      inno_major="${inno_version%%.*}"
+      inno_minor="${inno_version#*.}"
+      if [[ -z "$inno_version" || ! "$inno_major" =~ ^[0-9]+$ || ! "$inno_minor" =~ ^[0-9]+$ || ( "$inno_major" -eq 1 && "$inno_minor" -lt 11 ) ]]; then
+        printf '%-14s %s%-8s %s\n' "$name" "$(red OLD)" "" "$used"
+        printf '               %s %s\n' "$(red '→ unsupported for Inno Setup 6.4.3.')" "$hint"
+        missing_optional=$((missing_optional + 1))
+        continue
+      fi
+      printf '%-14s %s%-8s %s (v%s)\n' "$name" "$(green OK)" "" "$used" "$inno_version"
+      continue
+    fi
     printf '%-14s %s%-8s %s\n' "$name" "$(green OK)" "" "$used"
   else
     if [[ "$required" == "1" ]]; then

--- a/scripts/package-all.ps1
+++ b/scripts/package-all.ps1
@@ -6,7 +6,8 @@ Requires a successful build first (dotnet build VintageStory.slnx -c Release).
 Targets: linux-x64, osx-x64, osx-arm64, win-x64. The optimized DLLs are
 platform-agnostic IL, so any host can target any platform - but quality varies
 (e.g. a .dmg needs macOS hdiutil or a Linux libdmg toolchain; the Windows
-package off-Windows needs innoextract). This script reports what the host can do
+package off-Windows downloads the official Inno 6.4.3 installer and needs
+innoextract >= 1.11). This script reports what the host can do
 and runs only the capable targets. There is no native ARM client for Linux or
 Windows - x64 runs there via emulation (box64 / Windows-on-ARM).
 

--- a/scripts/package-all.sh
+++ b/scripts/package-all.sh
@@ -78,13 +78,30 @@ if [[ -n "$INNO_VERSION" && ( "$INNO_MAJOR" -gt 1 || ( "$INNO_MAJOR" -eq 1 && "$
     INNO_USABLE=1
 fi
 
-if [[ -f "$REPO_ROOT/.vanilla/win-x64/vintagestory/Vintagestory.exe" ]] && command -v dotnet &>/dev/null; then
+WIN_CACHE_DIR="$REPO_ROOT/.vanilla/win-x64/vintagestory"
+HAS_WIN_CACHE=0
+if [[ -f "$WIN_CACHE_DIR/Vintagestory.exe" ]]; then
+    for marker in "$WIN_CACHE_DIR"/assets/version-*.txt; do
+        if [[ -f "$marker" ]]; then
+            HAS_WIN_CACHE=1
+            break
+        fi
+    done
+fi
+
+if ! command -v pwsh &>/dev/null; then
+    map_set CAP_QUALITY win-x64 "Blocked"
+    map_set CAP_NOTE win-x64 "need pwsh + dotnet for off-platform Windows packaging"
+elif ! command -v dotnet &>/dev/null; then
+    map_set CAP_QUALITY win-x64 "Blocked"
+    map_set CAP_NOTE win-x64 "need dotnet to cross-build the win-x64 launcher"
+elif [[ "$HAS_WIN_CACHE" -eq 1 ]]; then
     map_set CAP_QUALITY win-x64 "Degraded"
     map_set CAP_NOTE win-x64 "cross-build Optimum.exe + cached Windows client"
-elif [[ "$INNO_USABLE" -eq 1 ]] && command -v dotnet &>/dev/null; then
+elif [[ "$INNO_USABLE" -eq 1 ]]; then
     map_set CAP_QUALITY win-x64 "Degraded"
     map_set CAP_NOTE win-x64 "cross-build Optimum.exe + innoextract $INNO_VERSION for the official Inno 6.4.3 installer"
-elif [[ -n "$INNO_VERSION" && "$INNO_MAJOR" -eq 1 && "$INNO_MINOR" -lt 11 ]]; then
+elif [[ -n "$INNO_VERSION" && ( "$INNO_MAJOR" -lt 1 || ( "$INNO_MAJOR" -eq 1 && "$INNO_MINOR" -lt 11 ) ) ]]; then
     map_set CAP_QUALITY win-x64 "Blocked"
     map_set CAP_NOTE win-x64 "innoextract $INNO_VERSION is too old; need innoextract >= 1.11"
 elif [[ -z "$INNO_VERSION" ]]; then

--- a/scripts/package-all.sh
+++ b/scripts/package-all.sh
@@ -78,21 +78,20 @@ if [[ -n "$INNO_VERSION" && ( "$INNO_MAJOR" -gt 1 || ( "$INNO_MAJOR" -eq 1 && "$
     INNO_USABLE=1
 fi
 
+WIN_CACHE_DIR="$REPO_ROOT/.vanilla/win-x64/package-client"
 HAS_WIN_CACHE=0
-WIN_CACHE_DIRS=(
-    "$REPO_ROOT/.vanilla/win-x64/vintagestory"
-    "$REPO_ROOT/.vanilla/win-x64/package-client"
-)
-for win_cache_dir in "${WIN_CACHE_DIRS[@]}"; do
-    if [[ -f "$win_cache_dir/Vintagestory.exe" ]]; then
-        for marker in "$win_cache_dir"/assets/version-*.txt; do
-            if [[ -f "$marker" ]]; then
+if [[ -f "$WIN_CACHE_DIR/Vintagestory.exe" ]]; then
+    for marker in "$WIN_CACHE_DIR"/assets/version-*.txt; do
+        if [[ -f "$marker" ]]; then
+            marker_version="${marker##*/version-}"
+            marker_version="${marker_version%.txt}"
+            if [[ "$marker_version" == "$VERSION" ]]; then
                 HAS_WIN_CACHE=1
-                break 2
+                break
             fi
-        done
-    fi
-done
+        fi
+    done
+fi
 
 if ! command -v pwsh &>/dev/null; then
     map_set CAP_QUALITY win-x64 "Blocked"

--- a/scripts/package-all.sh
+++ b/scripts/package-all.sh
@@ -64,16 +64,35 @@ for arch in x64 arm64; do
     fi
 done
 
-# Windows target
-if command -v innoextract &>/dev/null && command -v dotnet &>/dev/null; then
-    map_set CAP_QUALITY win-x64 "Degraded"
-    map_set CAP_NOTE win-x64 "cross-build Optimum.exe + innoextract vanilla installer"
-elif [[ -d "$REPO_ROOT/.vanilla/win-x64/vintagestory" ]] && command -v dotnet &>/dev/null; then
+# Windows target. The distro package on older systems is often innoextract 1.9,
+# which cannot parse the official Inno Setup 6.4.3 installer. Require the
+# supported release line before advertising an uncached off-platform package.
+INNO_VERSION=""
+if command -v innoextract &>/dev/null; then
+    INNO_VERSION="$(innoextract --version 2>/dev/null | sed -n 's/^innoextract \([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1.\2/p' | head -n 1 || true)"
+fi
+INNO_MAJOR="${INNO_VERSION%%.*}"
+INNO_MINOR="${INNO_VERSION#*.}"
+INNO_USABLE=0
+if [[ -n "$INNO_VERSION" && ( "$INNO_MAJOR" -gt 1 || ( "$INNO_MAJOR" -eq 1 && "$INNO_MINOR" -ge 11 ) ) ]]; then
+    INNO_USABLE=1
+fi
+
+if [[ -f "$REPO_ROOT/.vanilla/win-x64/vintagestory/Vintagestory.exe" ]] && command -v dotnet &>/dev/null; then
     map_set CAP_QUALITY win-x64 "Degraded"
     map_set CAP_NOTE win-x64 "cross-build Optimum.exe + cached Windows client"
+elif [[ "$INNO_USABLE" -eq 1 ]] && command -v dotnet &>/dev/null; then
+    map_set CAP_QUALITY win-x64 "Degraded"
+    map_set CAP_NOTE win-x64 "cross-build Optimum.exe + innoextract $INNO_VERSION for the official Inno 6.4.3 installer"
+elif [[ -n "$INNO_VERSION" && "$INNO_MAJOR" -eq 1 && "$INNO_MINOR" -lt 11 ]]; then
+    map_set CAP_QUALITY win-x64 "Blocked"
+    map_set CAP_NOTE win-x64 "innoextract $INNO_VERSION is too old; need innoextract >= 1.11"
+elif [[ -z "$INNO_VERSION" ]]; then
+    map_set CAP_QUALITY win-x64 "Blocked"
+    map_set CAP_NOTE win-x64 "need innoextract >= 1.11 + dotnet for off-platform Windows packaging"
 else
     map_set CAP_QUALITY win-x64 "Blocked"
-    map_set CAP_NOTE win-x64 "need innoextract + dotnet for off-platform Windows packaging"
+    map_set CAP_NOTE win-x64 "need dotnet to cross-build the win-x64 launcher"
 fi
 
 # Print capability report

--- a/scripts/package-all.sh
+++ b/scripts/package-all.sh
@@ -78,16 +78,21 @@ if [[ -n "$INNO_VERSION" && ( "$INNO_MAJOR" -gt 1 || ( "$INNO_MAJOR" -eq 1 && "$
     INNO_USABLE=1
 fi
 
-WIN_CACHE_DIR="$REPO_ROOT/.vanilla/win-x64/vintagestory"
 HAS_WIN_CACHE=0
-if [[ -f "$WIN_CACHE_DIR/Vintagestory.exe" ]]; then
-    for marker in "$WIN_CACHE_DIR"/assets/version-*.txt; do
-        if [[ -f "$marker" ]]; then
-            HAS_WIN_CACHE=1
-            break
-        fi
-    done
-fi
+WIN_CACHE_DIRS=(
+    "$REPO_ROOT/.vanilla/win-x64/vintagestory"
+    "$REPO_ROOT/.vanilla/win-x64/package-client"
+)
+for win_cache_dir in "${WIN_CACHE_DIRS[@]}"; do
+    if [[ -f "$win_cache_dir/Vintagestory.exe" ]]; then
+        for marker in "$win_cache_dir"/assets/version-*.txt; do
+            if [[ -f "$marker" ]]; then
+                HAS_WIN_CACHE=1
+                break 2
+            fi
+        done
+    fi
+done
 
 if ! command -v pwsh &>/dev/null; then
     map_set CAP_QUALITY win-x64 "Blocked"

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -52,6 +52,15 @@ function Test-WindowsHost {
     ($env:OS -eq 'Windows_NT') -or (($null -ne $IsWindows) -and $IsWindows)
 }
 
+function Get-WindowsClientVersion {
+    param([string]$ClientDir)
+    $assetsDir = Join-Path $ClientDir 'assets'
+    $marker = Get-ChildItem -Path $assetsDir -Filter 'version-*.txt' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($marker -and $marker.BaseName -match '^version-(.+)$') { return $Matches[1] }
+    return $null
+}
+
 # Resolve a local Windows vanilla install or populate the cross-platform cache
 # from the official installer. Native Windows keeps using the caller's local
 # installation; only non-Windows hosts need innoextract.
@@ -62,12 +71,18 @@ function Resolve-WindowsVanilla {
         [string]$InstallerPath
     )
     $winDir = Join-Path (Join-Path $RepoRoot '.vanilla/win-x64') 'vintagestory'
-    if (Test-Path (Join-Path $winDir 'Vintagestory.exe')) { return $winDir }
+    $cachedVersion = Get-WindowsClientVersion -ClientDir $winDir
+    if ((Test-Path (Join-Path $winDir 'Vintagestory.exe')) -and $cachedVersion -eq $RequestedVersion) {
+        return $winDir
+    }
 
     $legacyWin = Join-Path (Join-Path $RepoRoot '.vanilla') 'vintagestory'
-    if ((Test-WindowsHost) -and (Test-Path (Join-Path $legacyWin 'Vintagestory.exe'))) { return $legacyWin }
-
     if (Test-WindowsHost) {
+        if (Test-Path (Join-Path $legacyWin 'Vintagestory.exe')) { return $legacyWin }
+        if (Test-Path (Join-Path $winDir 'Vintagestory.exe')) {
+            $reported = if ($cachedVersion) { $cachedVersion } else { 'unknown' }
+            throw "Cached Windows client at $winDir is version $reported, requested $RequestedVersion. Pass -VanillaDir with the correct installation or refresh the cache."
+        }
         throw 'Vintage Story installation not found. Pass -VanillaDir with the folder that contains Vintagestory.exe.'
     }
 
@@ -77,8 +92,10 @@ function Resolve-WindowsVanilla {
         throw "Off-platform Windows packaging requires innoextract >= 1.11 ($detected). Install a current release from https://github.com/crazy-max/innoextract/releases."
     }
 
+    $cacheParent = Split-Path -Parent $winDir
     $archiveCache = Join-Path $RepoRoot '.vanilla/archives'
     New-Item -ItemType Directory -Force -Path $archiveCache | Out-Null
+    New-Item -ItemType Directory -Force -Path $cacheParent | Out-Null
     if (-not $InstallerPath) {
         $InstallerPath = Join-Path $archiveCache "vs_install_win-x64_$RequestedVersion.exe"
     } else {
@@ -88,7 +105,7 @@ function Resolve-WindowsVanilla {
     if (-not (Test-Path $InstallerPath)) {
         $url = "https://cdn.vintagestory.at/gamefiles/stable/vs_install_win-x64_$RequestedVersion.exe"
         Write-Host "Downloading $url (~570MB)"
-        $partial = "$InstallerPath.partial"
+        $partial = "$InstallerPath.$([Guid]::NewGuid().ToString('N')).partial"
         Remove-Item -Force -ErrorAction SilentlyContinue $partial
         Invoke-NativeStep { curl -L --fail --progress-bar -o $partial $url }
         if ($LASTEXITCODE -ne 0) {
@@ -111,7 +128,9 @@ function Resolve-WindowsVanilla {
         throw "innoextract $innoVersion could not inspect the official installer '$InstallerPath'. The installer uses a newer or unsupported Inno Setup format."
     }
 
-    $extractRoot = Join-Path ([IO.Path]::GetTempPath()) "Optimum-win-extract-$([Guid]::NewGuid().ToString('N'))"
+    # Keep staging beside the cache so promotion is a same-volume directory
+    # move instead of a potentially non-atomic cross-filesystem copy.
+    $extractRoot = Join-Path $cacheParent ".innoextract-stage-$([Guid]::NewGuid().ToString('N'))"
     New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
     try {
         Write-Host "Extracting with innoextract $innoVersion to the Windows client cache"
@@ -129,10 +148,28 @@ function Resolve-WindowsVanilla {
                 throw "innoextract completed but the Windows client is missing '$required'."
             }
         }
+        $extractedVersion = Get-WindowsClientVersion -ClientDir $sourceRoot
+        if ($extractedVersion -ne $RequestedVersion) {
+            $reported = if ($extractedVersion) { $extractedVersion } else { 'unknown' }
+            throw "Installer extracted Vintage Story $reported, requested $RequestedVersion."
+        }
 
-        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $winDir) | Out-Null
-        if (Test-Path $winDir) { Remove-Item -Recurse -Force $winDir }
-        Move-Item -Path $sourceRoot -Destination $winDir
+        $backupDir = Join-Path $cacheParent ".vintagestory-backup-$([Guid]::NewGuid().ToString('N'))"
+        $promoted = $false
+        try {
+            if (Test-Path $winDir) { Move-Item -Path $winDir -Destination $backupDir }
+            Move-Item -Path $sourceRoot -Destination $winDir
+            $promoted = $true
+        } catch {
+            if (-not (Test-Path $winDir) -and (Test-Path $backupDir)) {
+                Move-Item -Path $backupDir -Destination $winDir
+            }
+            throw
+        } finally {
+            if ($promoted -and (Test-Path $backupDir)) {
+                Remove-Item -Recurse -Force $backupDir -ErrorAction SilentlyContinue
+            }
+        }
     } finally {
         if (Test-Path $extractRoot) { Remove-Item -Recurse -Force $extractRoot -ErrorAction SilentlyContinue }
     }

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -11,16 +11,17 @@ Also compress the folder into Optimum-v<version>-win-x64.zip.
 
 .PARAMETER VanillaDir
 Path to an existing Vintage Story Windows installation. When omitted, the
-script uses .vanilla/win-x64/vintagestory when that cache matches the requested
-version. If off-platform extraction is needed, it uses the separate
+script uses the shared .vanilla/win-x64/vintagestory cache on Windows. On
+non-Windows hosts, automatic packaging uses the separate
 .vanilla/win-x64/package-client cache so the bootstrap/decompile cache remains
 available to make run and make patch-il.
 
 .PARAMETER ClientArchive
 Path to an official Vintage Story Windows installer. On non-Windows hosts,
 the default is .vanilla/archives/vs_install_win-x64_<version>.exe; a missing
-archive is downloaded and extracted with innoextract >= 1.11. Windows hosts
-continue to use a native installation or -VanillaDir.
+archive is downloaded and extracted with innoextract >= 1.11. A matching
+package-client cache avoids the extractor. Windows hosts continue to use a
+native installation or -VanillaDir.
 
 .EXAMPLE
 .\scripts\package.ps1 -VanillaDir C:\Games\VintageStory
@@ -74,25 +75,19 @@ function Resolve-WindowsVanilla {
     )
     $winRoot = Join-Path $RepoRoot '.vanilla/win-x64'
     $winDir = Join-Path $winRoot 'vintagestory'
-    $cachedVersion = Get-WindowsClientVersion -ClientDir $winDir
-    if ((Test-Path (Join-Path $winDir 'Vintagestory.exe')) -and $cachedVersion -eq $RequestedVersion) {
-        return $winDir
-    }
-
-    $legacyWin = Join-Path (Join-Path $RepoRoot '.vanilla') 'vintagestory'
     if (Test-WindowsHost) {
+        $cachedVersion = Get-WindowsClientVersion -ClientDir $winDir
+        if ((Test-Path (Join-Path $winDir 'Vintagestory.exe')) -and $cachedVersion -eq $RequestedVersion) {
+            return $winDir
+        }
+
+        $legacyWin = Join-Path (Join-Path $RepoRoot '.vanilla') 'vintagestory'
         if (Test-Path (Join-Path $legacyWin 'Vintagestory.exe')) { return $legacyWin }
         if (Test-Path (Join-Path $winDir 'Vintagestory.exe')) {
             $reported = if ($cachedVersion) { $cachedVersion } else { 'unknown' }
             throw "Cached Windows client at $winDir is version $reported, requested $RequestedVersion. Pass -VanillaDir with the correct installation or refresh the cache."
         }
         throw 'Vintage Story installation not found. Pass -VanillaDir with the folder that contains Vintagestory.exe.'
-    }
-
-    $innoVersion = Get-InnoextractVersion
-    if (-not $innoVersion -or $innoVersion -lt [Version]'1.11') {
-        $detected = if ($innoVersion) { "detected $innoVersion" } else { 'not found' }
-        throw "Off-platform Windows packaging requires innoextract >= 1.11 ($detected). Install a current release from https://github.com/crazy-max/innoextract/releases."
     }
 
     # Never replace the shared bootstrap/decompile cache. It is also the donor
@@ -102,6 +97,12 @@ function Resolve-WindowsVanilla {
     $packageCachedVersion = Get-WindowsClientVersion -ClientDir $cacheDir
     if ((Test-Path (Join-Path $cacheDir 'Vintagestory.exe')) -and $packageCachedVersion -eq $RequestedVersion) {
         return $cacheDir
+    }
+
+    $innoVersion = Get-InnoextractVersion
+    if (-not $innoVersion -or $innoVersion -lt [Version]'1.11') {
+        $detected = if ($innoVersion) { "detected $innoVersion" } else { 'not found' }
+        throw "Off-platform Windows packaging requires innoextract >= 1.11 ($detected). Install a current release from https://github.com/crazy-max/innoextract/releases."
     }
 
     $cacheParent = Split-Path -Parent $cacheDir

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -11,8 +11,10 @@ Also compress the folder into Optimum-v<version>-win-x64.zip.
 
 .PARAMETER VanillaDir
 Path to an existing Vintage Story Windows installation. When omitted, the
-script uses .vanilla/win-x64/vintagestory or acquires the official client on
-non-Windows hosts.
+script uses .vanilla/win-x64/vintagestory when that cache matches the requested
+version. If off-platform extraction is needed, it uses the separate
+.vanilla/win-x64/package-client cache so the bootstrap/decompile cache remains
+available to make run and make patch-il.
 
 .PARAMETER ClientArchive
 Path to an official Vintage Story Windows installer. On non-Windows hosts,
@@ -70,7 +72,8 @@ function Resolve-WindowsVanilla {
         [string]$RequestedVersion,
         [string]$InstallerPath
     )
-    $winDir = Join-Path (Join-Path $RepoRoot '.vanilla/win-x64') 'vintagestory'
+    $winRoot = Join-Path $RepoRoot '.vanilla/win-x64'
+    $winDir = Join-Path $winRoot 'vintagestory'
     $cachedVersion = Get-WindowsClientVersion -ClientDir $winDir
     if ((Test-Path (Join-Path $winDir 'Vintagestory.exe')) -and $cachedVersion -eq $RequestedVersion) {
         return $winDir
@@ -92,7 +95,16 @@ function Resolve-WindowsVanilla {
         throw "Off-platform Windows packaging requires innoextract >= 1.11 ($detected). Install a current release from https://github.com/crazy-max/innoextract/releases."
     }
 
-    $cacheParent = Split-Path -Parent $winDir
+    # Never replace the shared bootstrap/decompile cache. It is also the donor
+    # used by make run and make patch-il. An off-platform package gets its own
+    # extracted client cache instead.
+    $cacheDir = Join-Path $winRoot 'package-client'
+    $packageCachedVersion = Get-WindowsClientVersion -ClientDir $cacheDir
+    if ((Test-Path (Join-Path $cacheDir 'Vintagestory.exe')) -and $packageCachedVersion -eq $RequestedVersion) {
+        return $cacheDir
+    }
+
+    $cacheParent = Split-Path -Parent $cacheDir
     $archiveCache = Join-Path $RepoRoot '.vanilla/archives'
     New-Item -ItemType Directory -Force -Path $archiveCache | Out-Null
     New-Item -ItemType Directory -Force -Path $cacheParent | Out-Null
@@ -154,15 +166,15 @@ function Resolve-WindowsVanilla {
             throw "Installer extracted Vintage Story $reported, requested $RequestedVersion."
         }
 
-        $backupDir = Join-Path $cacheParent ".vintagestory-backup-$([Guid]::NewGuid().ToString('N'))"
+        $backupDir = Join-Path $cacheParent ".package-client-backup-$([Guid]::NewGuid().ToString('N'))"
         $promoted = $false
         try {
-            if (Test-Path $winDir) { Move-Item -Path $winDir -Destination $backupDir }
-            Move-Item -Path $sourceRoot -Destination $winDir
+            if (Test-Path $cacheDir) { Move-Item -Path $cacheDir -Destination $backupDir }
+            Move-Item -Path $sourceRoot -Destination $cacheDir
             $promoted = $true
         } catch {
-            if (-not (Test-Path $winDir) -and (Test-Path $backupDir)) {
-                Move-Item -Path $backupDir -Destination $winDir
+            if (-not (Test-Path $cacheDir) -and (Test-Path $backupDir)) {
+                Move-Item -Path $backupDir -Destination $cacheDir
             }
             throw
         } finally {
@@ -174,8 +186,8 @@ function Resolve-WindowsVanilla {
         if (Test-Path $extractRoot) { Remove-Item -Recurse -Force $extractRoot -ErrorAction SilentlyContinue }
     }
 
-    if (Test-Path (Join-Path $winDir 'Vintagestory.exe')) { return $winDir }
-    throw "Extraction completed without producing $winDir/Vintagestory.exe."
+    if (Test-Path (Join-Path $cacheDir 'Vintagestory.exe')) { return $cacheDir }
+    throw "Extraction completed without producing $cacheDir/Vintagestory.exe."
 }
 
 Push-Location $repoRoot

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -10,12 +10,21 @@ Where to create the output folder (and zip). Default: repo root.
 Also compress the folder into Optimum-v<version>-win-x64.zip.
 
 .PARAMETER VanillaDir
-Path to an existing Vintage Story Windows installation.
+Path to an existing Vintage Story Windows installation. When omitted, the
+script uses .vanilla/win-x64/vintagestory or acquires the official client on
+non-Windows hosts.
+
+.PARAMETER ClientArchive
+Path to an official Vintage Story Windows installer. On non-Windows hosts,
+the default is .vanilla/archives/vs_install_win-x64_<version>.exe; a missing
+archive is downloaded and extracted with innoextract >= 1.11. Windows hosts
+continue to use a native installation or -VanillaDir.
 
 .EXAMPLE
 .\scripts\package.ps1 -VanillaDir C:\Games\VintageStory
 .\scripts\package.ps1 -VanillaDir C:\Games\VintageStory -Zip
 .\scripts\package.ps1 -VanillaDir C:\Games\VintageStory -OutputDir D:\releases -Zip
+pwsh ./scripts/package.ps1 -ClientArchive /tmp/vs_install_win-x64_1.22.7.exe -Zip
 #>
 
 [CmdletBinding()]
@@ -23,7 +32,8 @@ param(
     [string]$OutputDir,
     [switch]$Zip,
     [string]$Version,
-    [string]$VanillaDir
+    [string]$VanillaDir,
+    [string]$ClientArchive
 )
 
 $ErrorActionPreference = 'Stop'
@@ -38,23 +48,107 @@ if (-not $Version) {
 . "$PSScriptRoot/_hostcaps.ps1"
 . "$PSScriptRoot/_exec.ps1"
 
-# Resolve a local Windows vanilla install. This script does not download
-# Vintage Story.
+function Test-WindowsHost {
+    ($env:OS -eq 'Windows_NT') -or (($null -ne $IsWindows) -and $IsWindows)
+}
+
+# Resolve a local Windows vanilla install or populate the cross-platform cache
+# from the official installer. Native Windows keeps using the caller's local
+# installation; only non-Windows hosts need innoextract.
 function Resolve-WindowsVanilla {
-    param([string]$RepoRoot)
+    param(
+        [string]$RepoRoot,
+        [string]$RequestedVersion,
+        [string]$InstallerPath
+    )
     $winDir = Join-Path (Join-Path $RepoRoot '.vanilla/win-x64') 'vintagestory'
     if (Test-Path (Join-Path $winDir 'Vintagestory.exe')) { return $winDir }
 
     $legacyWin = Join-Path (Join-Path $RepoRoot '.vanilla') 'vintagestory'
-    if (($IsWindows -or ($env:OS -eq 'Windows_NT')) -and (Test-Path (Join-Path $legacyWin 'Vintagestory.exe'))) { return $legacyWin }
+    if ((Test-WindowsHost) -and (Test-Path (Join-Path $legacyWin 'Vintagestory.exe'))) { return $legacyWin }
 
-    throw 'Vintage Story installation not found. Pass -VanillaDir with the folder that contains Vintagestory.exe.'
+    if (Test-WindowsHost) {
+        throw 'Vintage Story installation not found. Pass -VanillaDir with the folder that contains Vintagestory.exe.'
+    }
+
+    $innoVersion = Get-InnoextractVersion
+    if (-not $innoVersion -or $innoVersion -lt [Version]'1.11') {
+        $detected = if ($innoVersion) { "detected $innoVersion" } else { 'not found' }
+        throw "Off-platform Windows packaging requires innoextract >= 1.11 ($detected). Install a current release from https://github.com/crazy-max/innoextract/releases."
+    }
+
+    $archiveCache = Join-Path $RepoRoot '.vanilla/archives'
+    New-Item -ItemType Directory -Force -Path $archiveCache | Out-Null
+    if (-not $InstallerPath) {
+        $InstallerPath = Join-Path $archiveCache "vs_install_win-x64_$RequestedVersion.exe"
+    } else {
+        $InstallerPath = [IO.Path]::GetFullPath($InstallerPath)
+    }
+
+    if (-not (Test-Path $InstallerPath)) {
+        $url = "https://cdn.vintagestory.at/gamefiles/stable/vs_install_win-x64_$RequestedVersion.exe"
+        Write-Host "Downloading $url (~570MB)"
+        $partial = "$InstallerPath.partial"
+        Remove-Item -Force -ErrorAction SilentlyContinue $partial
+        Invoke-NativeStep { curl -L --fail --progress-bar -o $partial $url }
+        if ($LASTEXITCODE -ne 0) {
+            Remove-Item -Force -ErrorAction SilentlyContinue $partial
+            throw "Download failed: $url"
+        }
+        if (-not (Test-Path $partial) -or (Get-Item $partial).Length -eq 0) {
+            Remove-Item -Force -ErrorAction SilentlyContinue $partial
+            throw "Download produced an empty installer: $url"
+        }
+        Move-Item -Force $partial $InstallerPath
+    } else {
+        Write-Host "Using cached $InstallerPath"
+    }
+
+    $innoextract = (Get-Command innoextract -ErrorAction Stop).Path
+    $info = @(Invoke-NativeStep { & $innoextract --info $InstallerPath 2>&1 })
+    $infoExitCode = $LASTEXITCODE
+    if ($infoExitCode -ne 0 -or (($info -join "`n") -notmatch '(?i)setup data version')) {
+        throw "innoextract $innoVersion could not inspect the official installer '$InstallerPath'. The installer uses a newer or unsupported Inno Setup format."
+    }
+
+    $extractRoot = Join-Path ([IO.Path]::GetTempPath()) "Optimum-win-extract-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
+    try {
+        Write-Host "Extracting with innoextract $innoVersion to the Windows client cache"
+        Invoke-NativeStep { & $innoextract --silent --extract --output-dir $extractRoot $InstallerPath }
+        if ($LASTEXITCODE -ne 0) {
+            throw "innoextract failed (exit $LASTEXITCODE) for $InstallerPath"
+        }
+
+        $sourceRoot = Join-Path $extractRoot 'app'
+        if (-not (Test-Path (Join-Path $sourceRoot 'Vintagestory.exe'))) {
+            $sourceRoot = $extractRoot
+        }
+        foreach ($required in @('Vintagestory.exe', 'VintagestoryLib.dll', 'assets/game/shaders')) {
+            if (-not (Test-Path (Join-Path $sourceRoot $required))) {
+                throw "innoextract completed but the Windows client is missing '$required'."
+            }
+        }
+
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $winDir) | Out-Null
+        if (Test-Path $winDir) { Remove-Item -Recurse -Force $winDir }
+        Move-Item -Path $sourceRoot -Destination $winDir
+    } finally {
+        if (Test-Path $extractRoot) { Remove-Item -Recurse -Force $extractRoot -ErrorAction SilentlyContinue }
+    }
+
+    if (Test-Path (Join-Path $winDir 'Vintagestory.exe')) { return $winDir }
+    throw "Extraction completed without producing $winDir/Vintagestory.exe."
 }
 
 Push-Location $repoRoot
 try {
     Show-HostCaps -Only 'win-x64' | Out-Null
-    $vanillaDir = if ($VanillaDir) { [IO.Path]::GetFullPath($VanillaDir) } else { Resolve-WindowsVanilla -RepoRoot $repoRoot }
+    $vanillaDir = if ($VanillaDir) {
+        [IO.Path]::GetFullPath($VanillaDir)
+    } else {
+        Resolve-WindowsVanilla -RepoRoot $repoRoot -RequestedVersion $Version -InstallerPath $ClientArchive
+    }
     if (-not (Test-Path (Join-Path $vanillaDir 'Vintagestory.exe'))) {
         throw "Vanilla Windows install not found: $vanillaDir"
     }
@@ -211,8 +305,8 @@ try {
         }
     }
 
-    # Validate the staged assets before shipping them. A tolerated-partial
-    # innounp extraction or a poisoned .vanilla cache carries zero-byte or
+    # Validate the staged assets before shipping them. A partial innoextract
+    # extraction or a poisoned .vanilla cache carries zero-byte or
     # truncated files into the stage, and a truncated shader then kills the
     # game at startup with an opaque GL error (the 0.2.1 "blur.vsh ...
     # unexpected $end at <EOF>" reports). Fail the package with a clear


### PR DESCRIPTION
## Summary

The off-platform Windows packaging path reported that innoextract was available, but scripts/package.ps1 still required a pre-extracted -VanillaDir. The official Vintage Story 1.22.7 installer uses Inno Setup 6.4.3, which the distro innoextract 1.9 cannot parse.

This change downloads or accepts the official Windows installer on non-Windows hosts, requires innoextract >= 1.11 only when the dedicated package cache is absent or stale, validates the installer with --info, extracts into a temporary directory, checks the executable, engine DLL, shader tree, and requested client version, then promotes the client into .vanilla/win-x64/package-client. A matching package-client cache avoids the extractor. The shared .vanilla/win-x64/vintagestory cache is never replaced by automatic off-platform packaging, so bootstrap, make run, and make patch-il keep their donor cache even after make deploy. Native Windows installations keep using -VanillaDir. The prerequisite report, capability dispatchers, Make target, README, and contract test use the same rules.

## Verification

- make check: passed, including innoextract 1.13.0.
- make build: passed with zero warnings and zero errors.
- make check-patches: passed, 68 applied and 48 Cecil.
- make check-compat: passed with 18 documented skips.
- make check-shaders: passed.
- dotnet test Optimum.Launcher.Tests/Optimum.Launcher.Tests.csproj -c Release --no-restore --verbosity quiet: 19 passed.
- Focused installer contract test: passed.
- Forced off-platform extraction with the official installer and innoextract 1.13.0: passed. The shared client cache was ignored, package-client promotion completed, and the shared vintagestory cache file set was unchanged.
- Cache-only package run with innoextract absent from PATH: passed using package-client.
- bash scripts/package-all.sh --targets win-x64 --version 1.22.7: passed. It built the Windows launcher, produced the Windows folder and ZIP, and unzip -tq passed using package-client.
- innoextract 1.13.0 --info, --test, and full extraction of the official installer passed.
- make test: 652 passed, 34 skipped, and 5 existing coverage assertions failed in InstallerPathNormalizationTests, FsrPipelineCoverageTests, and EntityRenderP0Tests. None of those tests or implementation targets is part of this change.

The tested extractor is the self-contained innoextract v1.13.0 release: https://github.com/crazy-max/innoextract/releases/tag/v1.13.0.