### PR TITLE
fix(worldgen): interlock unloads with worker footprints

### DIFF
--- a/Optimum.Patcher/Program.cs
+++ b/Optimum.Patcher/Program.cs
@@ -270,6 +270,8 @@ var membersToInject = new Dictionary<string, List<string>>
     ["Vintagestory.Server.ChunkServerThread"] = new()
     {
         "optimumReadPool",
+        "optimumWorldgenFootprints",
+        "TryAcquireOptimumWorldgenFootprint",
     },
     ["Vintagestory.Server.ServerSystemSupplyChunks"] = new()
     {
@@ -325,6 +327,7 @@ var membersToInject = new Dictionary<string, List<string>>
         "optimumUnloadGenRequests",
         "optimumUnloadGenChunks",
         "optimumUnloadGenMapChunks",
+        "optimumUnloadGenLeases",
     },
     ["Vintagestory.Server.ServerSystemCompressChunks"] = new()
     {

--- a/Optimum.Tests/optimum-worldgen-footprint-lease-tests.cs
+++ b/Optimum.Tests/optimum-worldgen-footprint-lease-tests.cs
@@ -64,4 +64,29 @@ public sealed class OptimumWorldgenFootprintLeaseTests
         lease!.Dispose();
         Assert.Null(blocked);
     }
+
+    [Fact]
+    public void UnloadCannotReserveAColumnInsideAWorkerFootprint()
+    {
+        var registry = new OptimumWorldgenFootprintRegistry();
+        var workerFootprint = new[]
+        {
+            new OptimumWorldgenFootprintKey(0, 10, 20),
+            new OptimumWorldgenFootprintKey(0, 11, 20),
+            new OptimumWorldgenFootprintKey(0, 10, 21),
+            new OptimumWorldgenFootprintKey(0, 11, 21),
+        };
+
+        Assert.True(registry.TryAcquire(workerFootprint, out OptimumWorldgenFootprintLease? workerLease));
+        Assert.False(registry.TryAcquire(
+            new[] { new OptimumWorldgenFootprintKey(0, 11, 20) },
+            out OptimumWorldgenFootprintLease? unloadLease));
+        Assert.Null(unloadLease);
+
+        workerLease!.Dispose();
+        Assert.True(registry.TryAcquire(
+            new[] { new OptimumWorldgenFootprintKey(0, 11, 20) },
+            out OptimumWorldgenFootprintLease? available));
+        available!.Dispose();
+    }
 }

--- a/Optimum.Tests/worldgen-r1-workspace-patch-contract-tests.cs
+++ b/Optimum.Tests/worldgen-r1-workspace-patch-contract-tests.cs
@@ -48,10 +48,34 @@ public sealed class WorldgenR1WorkspacePatchContractTests
     {
         string source = PatchReader.ReadPatch("patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch");
 
-        Assert.Contains("OptimumWorldgenFootprintRegistry optimumWorldgenFootprints", source);
+        Assert.Contains("chunkthread.optimumWorldgenFootprints", source);
         Assert.Contains("TryAcquireWorldgenFootprint", source);
         Assert.Contains("out OptimumWorldgenFootprintLease footprintLease", source);
         Assert.Contains("footprintLease?.Dispose()", source);
         Assert.Contains("requestedChunkColumn.FlagToRequeue();", source);
+    }
+
+    [Fact]
+    public void UnloadReservesTheSameFootprintUntilPersistenceCompletes()
+    {
+        string unload = PatchReader.ReadPatch("patches/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs.patch");
+        string thread = PatchReader.ReadPatch("patches/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs.patch");
+        string patcher = System.IO.File.ReadAllText(PatchReader.FindRepositoryFile("Optimum.Patcher/Program.cs"));
+
+        int acquire = unload.IndexOf("TryAcquireOptimumWorldgenFootprint", System.StringComparison.Ordinal);
+        int readLock = unload.IndexOf("item2.generatingLock.AcquireReadLock()", acquire, System.StringComparison.Ordinal);
+        int setChunks = unload.IndexOf("gameDatabase.SetChunks", readLock, System.StringComparison.Ordinal);
+        int setMapChunks = unload.IndexOf("gameDatabase.SetMapChunks", setChunks, System.StringComparison.Ordinal);
+        int dispose = unload.IndexOf("leases[i]?.Dispose()", setMapChunks, System.StringComparison.Ordinal);
+
+        Assert.True(acquire >= 0);
+        Assert.True(readLock > acquire);
+        Assert.True(setChunks > readLock);
+        Assert.True(setMapChunks > setChunks);
+        Assert.True(dispose > setMapChunks);
+        Assert.Contains("optimumWorldgenFootprints", thread);
+        Assert.Contains("TryAcquireOptimumWorldgenFootprint", thread);
+        Assert.Contains("\"TryAcquireOptimumWorldgenFootprint\"", patcher);
+        Assert.Contains("\"optimumUnloadGenLeases\"", patcher);
     }
 }

--- a/patches/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs b/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
-index ee7d12d..063d931 100644
+index ee7d12d..a347848 100644
 --- a/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ChunkServerThread.cs
 @@ -1,10 +1,11 @@
@@ -14,13 +14,15 @@ index ee7d12d..063d931 100644
  using Vintagestory.API.Server;
  using Vintagestory.Common;
  
-@@ -32,26 +33,37 @@ public class ChunkServerThread : ServerThread, IChunkProvider
+@@ -32,29 +33,68 @@ public class ChunkServerThread : ServerThread, IChunkProvider
  
  	public bool peekMode;
  
  	public int additionalWorldGenThreadsCount;
  
 +	internal OptimumChunkReadPool optimumReadPool;
++
++	internal OptimumWorldgenFootprintRegistry optimumWorldgenFootprints;
 +
 +	internal bool optimumExactWorldgenWorkerMode;
 +
@@ -56,5 +58,34 @@ index ee7d12d..063d931 100644
  		}
  	}
  
++	internal bool TryAcquireOptimumWorldgenFootprint(int dimension, int chunkX, int chunkZ, int chunkMapSizeX, int chunkMapSizeZ, out OptimumWorldgenFootprintLease footprintLease)
++	{
++		footprintLease = null;
++		OptimumWorldgenFootprintRegistry registry = optimumWorldgenFootprints;
++		if (additionalWorldGenThreadsCount <= 0 || registry == null)
++		{
++			return true;
++		}
++
++		const int radius = 1;
++		int minX = Math.Max(0, chunkX - radius);
++		int maxX = Math.Min(chunkMapSizeX - 1, chunkX + radius);
++		int minZ = Math.Max(0, chunkZ - radius);
++		int maxZ = Math.Min(chunkMapSizeZ - 1, chunkZ + radius);
++		var keys = new List<OptimumWorldgenFootprintKey>((maxX - minX + 1) * (maxZ - minZ + 1));
++		for (int x = minX; x <= maxX; x++)
++		{
++			for (int z = minZ; z <= maxZ; z++)
++			{
++				keys.Add(new OptimumWorldgenFootprintKey(dimension, x, z));
++			}
++		}
++
++		return registry.TryAcquire(keys, out footprintLease);
++	}
++
  	protected override void UpdatePausedStatus(bool newpause)
  	{
+ 		if (newpause != additionalThreadsPaused)
+ 		{
+ 			TogglePause(newpause);

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index 159b06c..f797597 100644
+index 159b06c..22b6600 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 @@ -1,9 +1,13 @@
@@ -16,7 +16,7 @@ index 159b06c..f797597 100644
  using Vintagestory.API.Config;
  using Vintagestory.API.Datastructures;
  using Vintagestory.API.MathTools;
-@@ -26,10 +30,62 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -26,10 +30,60 @@ internal class ServerSystemSupplyChunks : ServerSystem
  
  	private bool requiresSetEmptyFlag;
  
@@ -41,8 +41,6 @@ index 159b06c..f797597 100644
 +	private int optimumWorldgenWorkersStarted;
 +
 +	private int optimumWorldgenDispatchesInFlight;
-+
-+	private OptimumWorldgenFootprintRegistry optimumWorldgenFootprints;
 +
 +	/// <summary>
 +	/// Conflict lock for passes 3 (Vegetation) and 4 (NeighbourSunLightFlood).
@@ -79,7 +77,7 @@ index 159b06c..f797597 100644
  
  	private List<long> entitiesToRemove = new List<long>();
  
-@@ -54,36 +110,80 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -54,36 +108,80 @@ internal class ServerSystemSupplyChunks : ServerSystem
  	{
  		if (chunkthread.requestedChunkColumns.Count == 0 || !is8Core)
  		{
@@ -123,7 +121,7 @@ index 159b06c..f797597 100644
 +		optimumGeneratorTypeLocks = new Dictionary<Type, Lock>();
 +		optimumGeneratorMethodLocks = new Dictionary<MethodInfo, Lock>();
 +		optimumGeneratorLockRegistry = new Lock();
-+		optimumWorldgenFootprints = new OptimumWorldgenFootprintRegistry();
++		chunkthread.optimumWorldgenFootprints = new OptimumWorldgenFootprintRegistry();
 +		optimumLightConflictLock = new Lock();
 +		optimumAdaptiveController = new AdaptiveWorkerController(
 +			chunkthread.optimumExactWorldgenWorkerMode ? chunkthread.additionalWorldGenThreadsCount :
@@ -169,7 +167,7 @@ index 159b06c..f797597 100644
  		{
  			loadChunkAreaBlocking(result.Key.X1, result.Key.Z1, result.Key.X2, result.Key.Z2, isStartupLoad: false, result.Value.ChunkGenParams);
  			if (result.Value.OnLoaded != null)
-@@ -291,29 +391,44 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -291,29 +389,44 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		if (pauseAllWorldgenThreads > 0)
  		{
@@ -220,7 +218,7 @@ index 159b06c..f797597 100644
  		return false;
  	}
  
-@@ -419,57 +534,286 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -419,57 +532,286 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return stage == 0;
  		}
  		bool num = CanGenerateChunkColumn(chunkRequest);
@@ -479,13 +477,13 @@ index 159b06c..f797597 100644
 -			return 1;
 +			handler(chunkRequest);
 +			return;
-+		}
+ 		}
+-		return 0;
 +		Lock generatorLock = GetWorldgenGeneratorLock(handler);
 +		lock (generatorLock)
 +		{
 +			handler(chunkRequest);
- 		}
--		return 0;
++		}
 +	}
 +
 +	private bool TryClaimWorldgenPass(int pass)
@@ -526,7 +524,7 @@ index 159b06c..f797597 100644
  	public bool CanGenerateChunkColumn(ChunkColumnLoadRequest chunkRequest)
  	{
  		if (chunkRequest.CurrentIncompletePass_AsInt >= chunkRequest.untilPass || !ensurePrettyNeighbourhood(chunkRequest))
-@@ -931,32 +1275,112 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -931,32 +1273,112 @@ internal class ServerSystemSupplyChunks : ServerSystem
  	internal ServerChunk[] TryLoadChunkColumn(ChunkColumnLoadRequest chunkRequest)
  	{
  		int chunkMapSizeY = server.WorldMap.ChunkMapSizeY;
@@ -655,7 +653,7 @@ index 159b06c..f797597 100644
  		if (requiresSetEmptyFlag)
  		{
  			foreach (ServerChunk serverChunk in array)
-@@ -1038,10 +1462,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1038,10 +1460,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  	}
  
  	public void InitWorldgenAndSpawnChunks()
@@ -667,7 +665,7 @@ index 159b06c..f797597 100644
  		{
  			storyChunkSpawnEvents = new string[15]
  			{
-@@ -1278,10 +1703,15 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1278,10 +1701,15 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		long num3 = Environment.TickCount + 12000;
  		ServerMain.Logger.VerboseDebug("Starting area loading/generation: columns " + blockingRequestsRemaining + ", total queue length " + chunkthread.requestedChunkColumns.Count);
@@ -683,7 +681,7 @@ index 159b06c..f797597 100644
  			{
  				break;
  			}
-@@ -1299,34 +1729,57 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1299,34 +1727,57 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.StoryEvent("...");
  				}
  				storyEventPrints++;
@@ -743,7 +741,7 @@ index 159b06c..f797597 100644
  				ServerMain.Logger.Error("Attempting to force generate chunk columns from " + chunkX1 + "," + chunkZ1 + " to " + chunkX2 + "," + chunkZ2);
  				ServerMain.Logger.Error(chunkthread.additionalWorldGenThreadsCount + " additional worldgen threads active, number of 'undone' chunks is " + blockingRequestsRemaining);
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
-@@ -1340,12 +1793,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,12 +1791,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -761,7 +759,7 @@ index 159b06c..f797597 100644
  		try
  		{
  			if (server.Config.SkipEveryChunkRow > 0 && chunkRequest.chunkX % (server.Config.SkipEveryChunkRow + server.Config.SkipEveryChunkRowWidth) < server.Config.SkipEveryChunkRowWidth)
-@@ -1375,29 +1832,94 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1375,29 +1830,80 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			chunkRequest.MapChunk.DirtyForSaving = true;
  		}
  		finally
@@ -774,27 +772,13 @@ index 159b06c..f797597 100644
 +
 +	private bool TryAcquireWorldgenFootprint(ChunkColumnLoadRequest chunkRequest, out OptimumWorldgenFootprintLease footprintLease)
 +	{
-+		footprintLease = null;
-+		if (chunkthread.additionalWorldGenThreadsCount <= 0 || optimumWorldgenFootprints == null)
-+		{
-+			return true;
-+		}
-+
-+		int radius = 1;
-+		int minX = Math.Max(0, chunkRequest.chunkX - radius);
-+		int maxX = Math.Min(server.WorldMap.ChunkMapSizeX - 1, chunkRequest.chunkX + radius);
-+		int minZ = Math.Max(0, chunkRequest.chunkZ - radius);
-+		int maxZ = Math.Min(server.WorldMap.ChunkMapSizeZ - 1, chunkRequest.chunkZ + radius);
-+		var keys = new List<OptimumWorldgenFootprintKey>((maxX - minX + 1) * (maxZ - minZ + 1));
-+		for (int x = minX; x <= maxX; x++)
-+		{
-+			for (int z = minZ; z <= maxZ; z++)
-+			{
-+				keys.Add(new OptimumWorldgenFootprintKey(chunkRequest.dimension, x, z));
-+			}
-+		}
-+
-+		return optimumWorldgenFootprints.TryAcquire(keys, out footprintLease);
++		return chunkthread.TryAcquireOptimumWorldgenFootprint(
++			chunkRequest.dimension,
++			chunkRequest.chunkX,
++			chunkRequest.chunkZ,
++			server.WorldMap.ChunkMapSizeX,
++			server.WorldMap.ChunkMapSizeZ,
++			out footprintLease);
  	}
  
  	private void runGenerators(ChunkColumnLoadRequest chunkRequest, int forPass)
@@ -858,7 +842,7 @@ index 159b06c..f797597 100644
  					break;
  				}
  			}
-@@ -1507,43 +2029,95 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1507,43 +2013,95 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");
  	}
  
@@ -896,7 +880,7 @@ index 159b06c..f797597 100644
 -			if (chunkthread.requestedChunkColumns.Count > 0 && (!server.Suspended || server.RunPhase == EnumServerRunPhase.WorldReady))
 +			// Automatic mode may raise the cap after spawn. Exact mode skips this path.
 +			if (!chunkthread.optimumExactWorldgenWorkerMode && Volatile.Read(ref optimumPostSpawnRaised) == 0 && server.RunPhase == EnumServerRunPhase.RunGame)
-+			{
+ 			{
 +				if (Interlocked.CompareExchange(ref optimumPostSpawnRaised, 1, 0) == 0)
 +				{
 +					int maxCeiling = OptimumConfig.GetWorldgenWorkerCeiling(Environment.ProcessorCount, server.ReducedServerThreads);
@@ -912,7 +896,7 @@ index 159b06c..f797597 100644
 +			// Adaptive cap enforcement: if this worker's index exceeds the
 +			// current cap, yield until the controller raises it back.
 +			if (optimumWorkerIndex > optimumAdaptiveController.ActiveWorkerCap)
- 			{
++			{
 +				Thread.Sleep(10);
 +				continue;
 +			}
@@ -958,7 +942,7 @@ index 159b06c..f797597 100644
  			Thread.Sleep(1);
  		}
  		BlockAccessorWorldGen.ThreadDispose();
-@@ -1554,13 +2128,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1554,13 +2112,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		BlockAccessorWorldGen.ThreadDispose();
  	}
  

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs.patch
@@ -1,8 +1,20 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs
-index 642722c..ddf48f6 100644
+index 642722c..c95c743 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemUnloadChunks.cs
-@@ -38,10 +38,21 @@ internal class ServerSystemUnloadChunks : ServerSystem
+@@ -1,10 +1,11 @@
+ using System;
+ using System.Collections.Concurrent;
+ using System.Collections.Generic;
+ using System.Runtime;
+ using Vintagestory.API.Common;
++using Vintagestory.API.Config;
+ using Vintagestory.API.Datastructures;
+ using Vintagestory.API.MathTools;
+ using Vintagestory.API.Server;
+ using Vintagestory.API.Util;
+ using Vintagestory.Common.Database;
+@@ -38,10 +39,21 @@ internal class ServerSystemUnloadChunks : ServerSystem
  
  	private float accum120s;
  
@@ -24,7 +36,7 @@ index 642722c..ddf48f6 100644
  	{
  		this.chunkthread = chunkthread;
  		server.api.ChatCommands.GetOrCreate("chunk").BeginSubCommand("unload").WithDescription("Toggle on / off whether the server(and thus in turn the client) should unload chunks")
-@@ -354,13 +365,21 @@ internal class ServerSystemUnloadChunks : ServerSystem
+@@ -354,14 +366,22 @@ internal class ServerSystemUnloadChunks : ServerSystem
  			chunk.Dispose();
  		}
  		return flag;
@@ -35,19 +47,21 @@ index 642722c..ddf48f6 100644
 +	private List<ChunkColumnLoadRequest> optimumUnloadGenRequests;
 +	private List<DbChunk> optimumUnloadGenChunks;
 +	private List<DbChunk> optimumUnloadGenMapChunks;
++	private List<OptimumWorldgenFootprintLease> optimumUnloadGenLeases;
 +
  	internal void UnloadGeneratingChunkColumns(long timeToLive)
  	{
 -		List<ChunkColumnLoadRequest> list = new List<ChunkColumnLoadRequest>();
+-		int num = 0;
 +		// Optimum: reuse lists instead of allocating per call.
 +		List<ChunkColumnLoadRequest> list = optimumUnloadGenRequests ??= new List<ChunkColumnLoadRequest>();
 +		list.Clear();
- 		int num = 0;
  		foreach (ChunkColumnLoadRequest item in chunkthread.requestedChunkColumns.Snapshot())
  		{
  			if (item.Chunks == null || item.Disposed)
  			{
-@@ -391,12 +410,15 @@ internal class ServerSystemUnloadChunks : ServerSystem
+ 				continue;
+@@ -391,85 +411,127 @@ internal class ServerSystemUnloadChunks : ServerSystem
  		}
  		if (list.Count == 0)
  		{
@@ -55,17 +69,133 @@ index 642722c..ddf48f6 100644
  		}
 -		List<DbChunk> list2 = new List<DbChunk>();
 -		List<DbChunk> list3 = new List<DbChunk>();
+-		using FastMemoryStream ms = new FastMemoryStream();
+-		foreach (ChunkColumnLoadRequest item2 in list)
 +		// Optimum: reuse DbChunk lists
 +		List<DbChunk> list2 = optimumUnloadGenChunks ??= new List<DbChunk>();
 +		list2.Clear();
 +		List<DbChunk> list3 = optimumUnloadGenMapChunks ??= new List<DbChunk>();
 +		list3.Clear();
- 		using FastMemoryStream ms = new FastMemoryStream();
- 		foreach (ChunkColumnLoadRequest item2 in list)
++		List<OptimumWorldgenFootprintLease> leases = optimumUnloadGenLeases ??= new List<OptimumWorldgenFootprintLease>();
++		leases.Clear();
++		try
  		{
- 			item2.generatingLock.AcquireReadLock();
- 			try
-@@ -449,27 +471,30 @@ internal class ServerSystemUnloadChunks : ServerSystem
+-			item2.generatingLock.AcquireReadLock();
+-			try
++			using FastMemoryStream ms = new FastMemoryStream();
++			foreach (ChunkColumnLoadRequest item2 in list)
+ 			{
+-				for (int j = 0; j < item2.Chunks.Length; j++)
++				OptimumWorldgenFootprintLease lease = null;
++				try
+ 				{
+-					if (item2.Chunks[j].DirtyForSaving)
++					if (!chunkthread.TryAcquireOptimumWorldgenFootprint(
++						item2.dimension,
++						item2.chunkX,
++						item2.chunkZ,
++						server.WorldMap.ChunkMapSizeX,
++						server.WorldMap.ChunkMapSizeZ,
++						out lease))
+ 					{
+-						item2.Chunks[j].DirtyForSaving = false;
+-						list2.Add(new DbChunk
+-						{
+-							Position = new ChunkPos(item2.chunkX, j, item2.chunkZ, 0),
+-							Data = item2.Chunks[j].ToBytes(ms)
+-						});
++						continue;
+ 					}
+-				}
+-				ServerMapChunk mapChunk = item2.MapChunk;
+-				if (mapChunk != null)
+-				{
+-					if (mapChunk.DirtyForSaving)
++
++					item2.generatingLock.AcquireReadLock();
++					try
+ 					{
+-						list3.Add(new DbChunk
++						for (int j = 0; j < item2.Chunks.Length; j++)
++						{
++							if (item2.Chunks[j].DirtyForSaving)
++							{
++								item2.Chunks[j].DirtyForSaving = false;
++								list2.Add(new DbChunk
++								{
++									Position = new ChunkPos(item2.chunkX, j, item2.chunkZ, 0),
++									Data = item2.Chunks[j].ToBytes(ms)
++								});
++							}
++						}
++						ServerMapChunk mapChunk = item2.MapChunk;
++						if (mapChunk != null)
+ 						{
+-							Position = new ChunkPos(item2.chunkX, 0, item2.chunkZ, 0),
+-							Data = mapChunk.ToBytes(ms)
+-						});
++							if (mapChunk.DirtyForSaving)
++							{
++								list3.Add(new DbChunk
++								{
++									Position = new ChunkPos(item2.chunkX, 0, item2.chunkZ, 0),
++									Data = mapChunk.ToBytes(ms)
++								});
++							}
++							mapChunk.DirtyForSaving = false;
++							server.loadedMapChunks.Remove(item2.mapIndex2d);
++						}
++					}
++					finally
++					{
++						item2.generatingLock.ReleaseReadLock();
++					}
++					if (!chunkthread.requestedChunkColumns.Remove(item2.mapIndex2d))
++					{
++						throw new Exception("Chunkrequest no longer in queue? Race condition?");
++					}
++					server.ChunkColumnRequested.Remove(item2.mapIndex2d);
++					if (lease != null)
++					{
++						leases.Add(lease);
++						lease = null;
+ 					}
+-					mapChunk.DirtyForSaving = false;
+-					server.loadedMapChunks.Remove(item2.mapIndex2d);
++				}
++				finally
++				{
++					lease?.Dispose();
+ 				}
+ 			}
+-			finally
++			if (list2.Count > 0)
+ 			{
+-				item2.generatingLock.ReleaseReadLock();
++				chunkthread.gameDatabase.SetChunks(list2);
+ 			}
+-			if (!chunkthread.requestedChunkColumns.Remove(item2.mapIndex2d))
++			if (list3.Count > 0)
+ 			{
+-				throw new Exception("Chunkrequest no longer in queue? Race condition?");
++				chunkthread.gameDatabase.SetMapChunks(list3);
+ 			}
+-			server.ChunkColumnRequested.Remove(item2.mapIndex2d);
+-			num++;
+-		}
+-		if (list2.Count > 0)
+-		{
+-			chunkthread.gameDatabase.SetChunks(list2);
+ 		}
+-		if (list3.Count > 0)
++		finally
+ 		{
+-			chunkthread.gameDatabase.SetMapChunks(list3);
++			for (int i = 0; i < leases.Count; i++)
++			{
++				leases[i]?.Dispose();
++			}
++			leases.Clear();
  		}
  	}
  
@@ -99,7 +229,7 @@ index 642722c..ddf48f6 100644
  			long key = server.WorldMap.MapChunkIndex2D(vec2i.X, vec2i.Y);
  			server.loadedMapChunks.TryGetValue(key, out value);
  			value?.MarkFresh();
-@@ -545,12 +570,15 @@ internal class ServerSystemUnloadChunks : ServerSystem
+@@ -545,12 +607,15 @@ internal class ServerSystemUnloadChunks : ServerSystem
  		}
  	}
  


### PR DESCRIPTION
## Summary

`ServerSystemSupplyChunks` already reserves the target column and its one-column border while a parallel worker runs world generation. `ServerSystemUnloadChunks` could still remove a stale generating column without consulting that reservation. A worker could therefore keep reading or writing a neighbouring column after unload had removed it.

This change moves the footprint registry to `ChunkServerThread`, uses one radius-one acquisition helper from both paths, and makes unload acquire the footprint before `generatingLock`. Unload keeps each acquired lease until `SetChunks` and `SetMapChunks` finish. A conflicting candidate stays queued for a later unload pass. The serial path remains unchanged.

This addresses the concrete synchronization lead in #31. The reporter's complete all-rock reproduction is not claimed as independently reproduced here.

## Validation

- `dotnet build VintageStory.slnx -c Release --no-restore`: passed with 0 warnings and 0 errors.
- Focused worldgen tests: 8 passed.
- `make check-patches`: 68 patches applied, 48 Cecil patches, 0 pending, unavailable, or conflicting patches.
- `make check-compat`: passed with 18 allowlisted skips.
- `make check-shaders`: passed.
- `make VANILLA_DIR=.vanilla/linux-x64/vintagestory patch-il`: passed with 126/126 required methods patched, 179 members injected, and 2 hooks.
- Fixed-seed parity harness on fresh worlds, serial and 1, 2, and 3 worker modes: all passed the vanilla divergence gate with no worldgen or scheduler errors.
- One-trial streaming sweep on fresh worlds, serial and 1, 2, and 3 worker modes: exit code 0 with no validator failures. The pregen marker was unreliable in this run, so these results are execution evidence rather than a performance comparison.
- `make test`: 654 passed, 34 skipped, and 5 existing unrelated coverage failures in `InstallerPathNormalizationTests` (3), `EntityRenderP0Tests` (1), and `FsrPipelineCoverageTests` (1).

Addresses #31.
