### PR TITLE
fix(shader): guard map cache during shader reloads

### DIFF
--- a/.github/workflows/ci-platform-bootstrap.yml
+++ b/.github/workflows/ci-platform-bootstrap.yml
@@ -102,6 +102,10 @@ jobs:
         shell: bash
         run: dotnet test Optimum.Tests/Optimum.Tests.csproj -c Release --no-build --nologo
 
+      - name: Run launcher tests
+        shell: bash
+        run: dotnet test Optimum.Launcher.Tests/Optimum.Launcher.Tests.csproj -c Release --no-build --nologo
+
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -196,6 +200,10 @@ jobs:
         shell: bash
         run: dotnet test Optimum.Tests/Optimum.Tests.csproj -c Release --no-build --nologo
 
+      - name: Run launcher tests
+        shell: bash
+        run: dotnet test Optimum.Launcher.Tests/Optimum.Launcher.Tests.csproj -c Release --no-build --nologo
+
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -287,6 +295,10 @@ jobs:
         shell: bash
         run: dotnet test Optimum.Tests/Optimum.Tests.csproj -c Release --no-build --nologo
 
+      - name: Run launcher tests
+        shell: bash
+        run: dotnet test Optimum.Launcher.Tests/Optimum.Launcher.Tests.csproj -c Release --no-build --nologo
+
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -373,6 +385,10 @@ jobs:
         shell: bash
         run: dotnet test Optimum.Tests/Optimum.Tests.csproj -c Release --no-build --nologo
 
+      - name: Run launcher tests
+        shell: bash
+        run: dotnet test Optimum.Launcher.Tests/Optimum.Launcher.Tests.csproj -c Release --no-build --nologo
+
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -458,6 +474,10 @@ jobs:
       - name: Run tests
         shell: bash
         run: dotnet test Optimum.Tests/Optimum.Tests.csproj -c Release --no-build --nologo
+
+      - name: Run launcher tests
+        shell: bash
+        run: dotnet test Optimum.Launcher.Tests/Optimum.Launcher.Tests.csproj -c Release --no-build --nologo
 
       - name: Upload logs on failure
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ settings: ## Open client settings in editor
 
 test: build ## Run unit tests (separate from release build)
 	dotnet test Optimum.Tests/Optimum.Tests.csproj -c Release --no-restore --verbosity quiet
+	dotnet test Optimum.Launcher.Tests/Optimum.Launcher.Tests.csproj -c Release --no-restore --verbosity quiet
 
 coverage: build ## Run tests with coverage, report per-assembly (see which % is Optimum's own code vs the vanilla donor)
 	rm -rf .build/coverage

--- a/Optimum.Launcher.Tests/Optimum.Launcher.Tests.csproj
+++ b/Optimum.Launcher.Tests/Optimum.Launcher.Tests.csproj
@@ -11,5 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Optimum.Launcher\Optimum.Launcher.csproj" />
+    <ProjectReference Include="..\optimum-api-contracts\optimum-api-contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/Optimum.Launcher.Tests/ShaderCompatibilityScannerTests.cs
+++ b/Optimum.Launcher.Tests/ShaderCompatibilityScannerTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Text;
 using Optimum.Launcher;
+using Vintagestory.API.Config;
 using Xunit;
 
 namespace Optimum.Launcher.Tests;
@@ -25,6 +27,7 @@ public sealed class ShaderCompatibilityScannerTests : IDisposable
 
         Assert.Empty(report.Sources);
         Assert.DoesNotContain("Oit", report.DisabledFeatures);
+        Assert.DoesNotContain("MapPageCache", report.DisabledFeatures);
         Assert.DoesNotContain("EntityLightBatch", report.DisabledFeatures);
         Assert.DoesNotContain("EntityShaderStateCache", report.DisabledFeatures);
     }
@@ -49,7 +52,69 @@ public sealed class ShaderCompatibilityScannerTests : IDisposable
         Assert.Contains(report.Sources, source => source.Name == "VSSurvivalMod");
         Assert.Contains(report.Sources, source => source.Name == "CustomHook");
         Assert.Contains("Oit", report.DisabledFeatures);
+        Assert.Contains("MapPageCache", report.DisabledFeatures);
         Assert.Contains("EntityLightBatch", report.DisabledFeatures);
+    }
+
+    [Fact]
+    public void ExternalShaderAssetsDisableMapPageCache()
+    {
+        string dataPath = Path.Combine(_root, "data");
+        string archivePath = Path.Combine(
+            dataPath,
+            "Mods",
+            "AncestralBliss.zip");
+        Directory.CreateDirectory(Path.GetDirectoryName(archivePath)!);
+        using (ZipArchive archive = ZipFile.Open(archivePath, ZipArchiveMode.Create))
+        {
+            using StreamWriter writer = new(archive.CreateEntry(
+                "assets/ancestralblissshaders/shaders/chunkopaque.fsh").Open());
+            writer.Write("void main() { }");
+        }
+
+        ShaderCompatibilityReport report = ShaderCompatibilityScanner.Scan(
+            dataPath,
+            Path.Combine(_root, "game"),
+            "test");
+
+        Assert.Contains(report.Sources, source => source.Name == "AncestralBliss");
+        Assert.Contains("MapPageCache", report.DisabledFeatures);
+        Assert.Contains("GreedyMesh", report.DisabledFeatures);
+        Assert.Contains("ShaderPreprocessParallel", report.DisabledFeatures);
+    }
+
+    [Fact]
+    public void SavedShaderCompatibilityReportDisablesEffectiveMapPageCache()
+    {
+        string dataPath = Path.Combine(_root, "data");
+        string archivePath = Path.Combine(dataPath, "Mods", "AncestralBliss.zip");
+        Directory.CreateDirectory(Path.GetDirectoryName(archivePath)!);
+        using (ZipArchive archive = ZipFile.Open(archivePath, ZipArchiveMode.Create))
+        {
+            using StreamWriter writer = new(archive.CreateEntry(
+                "assets/ancestralblissshaders/shaders/chunkopaque.fsh").Open());
+            writer.Write("void main() { }");
+        }
+
+        ShaderCompatibilityReport report = ShaderCompatibilityScanner.Scan(
+            dataPath,
+            Path.Combine(_root, "game"),
+            "test");
+        ShaderCompatibilityScanner.SaveReport(dataPath, report);
+
+        bool originalEnabled = OptimumConfig.MapPageCacheEnabled;
+        try
+        {
+            OptimumConfig.MapPageCacheEnabled = true;
+            OptimumConfig.SetDataPath(dataPath);
+
+            Assert.Contains("MapPageCache", report.DisabledFeatures);
+            Assert.False(OptimumConfig.EffectiveMapPageCache);
+        }
+        finally
+        {
+            OptimumConfig.MapPageCacheEnabled = originalEnabled;
+        }
     }
 
     private static void WriteHookAssembly(string path)

--- a/Optimum.Launcher/Program.cs
+++ b/Optimum.Launcher/Program.cs
@@ -72,7 +72,28 @@ public static class Program
         catch (Exception ex)
         {
             shaderCompatibility = ShaderCompatibilityScanner.CreateConservativeReport(Version, ex.Message);
-            try { ShaderCompatibilityScanner.SaveReport(dataPath, shaderCompatibility); } catch { }
+            try
+            {
+                ShaderCompatibilityScanner.SaveReport(dataPath, shaderCompatibility);
+            }
+            catch (Exception saveException)
+            {
+                string reportPath = Path.Combine(dataPath, CacheDirName, ShaderCompatibilityScanner.ReportFileName);
+                try
+                {
+                    if (File.Exists(reportPath)) File.Delete(reportPath);
+                }
+                catch (Exception cleanupException)
+                {
+                    throw new IOException(
+                        "Could not save the conservative shader compatibility report or remove the previous report.",
+                        new AggregateException(ex, saveException, cleanupException));
+                }
+
+                Logger.LogError(
+                    $"[Optimum] Could not save the conservative shader compatibility report; " +
+                    $"removed any previous report to keep shader features disabled: {saveException.Message}");
+            }
         }
         Logger.Log($"[Optimum] Shader compatibility scan: sources={shaderCompatibility.Sources.Count}, " +
             $"shaders={shaderCompatibility.ShaderOwners.Count}, conflicts={shaderCompatibility.Conflicts.Count}, " +

--- a/Optimum.Launcher/ShaderCompatibilityScanner.cs
+++ b/Optimum.Launcher/ShaderCompatibilityScanner.cs
@@ -22,7 +22,7 @@ public static class ShaderCompatibilityScanner
     private static readonly string[] ShaderFeatures =
     [
         "GreedyMesh", "RenderScale", "GodRaysSampleCap", "EntityLightBatch",
-        "EntityShaderStateCache", "Oit", "ShaderPreprocessParallel"
+        "EntityShaderStateCache", "Oit", "MapPageCache", "ShaderPreprocessParallel"
     ];
 
     private static readonly (string Token, string Name)[] IndicatorTokens =
@@ -297,7 +297,8 @@ public static class ShaderCompatibilityScanner
         AddFeatureDecision(report, "GodRaysSampleCap", HasExternalShader(report, "godrays.fsh"),
             "external godrays shader owns the sample-count contract");
         bool externalShaderHooks = report.Sources.Any(x => x.Indicators.Any(IsShaderHookIndicator));
-        AddFeatureDecision(report, "ShaderPreprocessParallel", report.Sources.Any(x => x.ShaderFiles.Count > 0) || externalShaderHooks,
+        bool externalShaderAssets = report.Sources.Any(x => x.ShaderFiles.Count > 0);
+        AddFeatureDecision(report, "ShaderPreprocessParallel", externalShaderAssets || externalShaderHooks,
             "external shader assets or shader hooks can depend on load order");
         AddFeatureDecision(report, "EntityLightBatch", externalShaderHooks,
             "external render hooks can observe entity-light update ordering");
@@ -305,6 +306,8 @@ public static class ShaderCompatibilityScanner
             "external render hooks can observe entity shader state");
         AddFeatureDecision(report, "Oit", externalShaderHooks || HasExternalShader(report, "cloudvolumetric.fsh"),
             "external render or cloud shader owns the OIT integration point");
+        AddFeatureDecision(report, "MapPageCache", externalShaderAssets || externalShaderHooks,
+            "external shader assets or shader hooks can dispose registered programs during reload");
 
         if (report.ScanFailed)
         {
@@ -371,8 +374,28 @@ public static class ShaderCompatibilityScanner
     {
         string normalized = path.Replace('\\', '/');
         int marker = normalized.IndexOf("assets/game/shaders/", StringComparison.OrdinalIgnoreCase);
-        if (marker < 0) return null;
-        string shader = normalized[marker..];
+        string shader;
+        if (marker >= 0)
+        {
+            shader = normalized[marker..];
+        }
+        else
+        {
+            marker = normalized.IndexOf("/shaders/", StringComparison.OrdinalIgnoreCase);
+            if (marker >= 0)
+            {
+                shader = normalized[(marker + 1)..];
+            }
+            else if (normalized.StartsWith("shaders/", StringComparison.OrdinalIgnoreCase))
+            {
+                shader = normalized;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         string extension = Path.GetExtension(shader);
         if (extension is not ".fsh" and not ".vsh" and not ".gsh") return null;
         return shader.ToLowerInvariant();

--- a/Optimum.Tests/entity-render-p0-tests.cs
+++ b/Optimum.Tests/entity-render-p0-tests.cs
@@ -154,8 +154,8 @@ public class EntityRenderP0Tests
         string renderer = PatchReader.ReadPatch("patches/runtime/VSEssentials/Vintagestory/GameContent/EntityShapeRenderer.cs.patch");
         string patcher = File.ReadAllText(PatchReader.FindRepositoryFile("Optimum.Patcher/Program.cs"));
 
-        Assert.Contains("OptimumConfig.EntityLightBatchEnabled && !optimumEntityLightBatchDisabled && optimumEntityLightPreviousSampleCount >= OptimumEntityLightMinimumSamples ? PrepareOptimumEntityLights() : 0", system);
-        Assert.Contains("OptimumConfig.EntityShaderStateCacheEnabled", system);
+        Assert.Contains("OptimumConfig.EffectiveEntityLightBatch && !optimumEntityLightBatchDisabled && optimumEntityLightPreviousSampleCount >= OptimumEntityLightMinimumSamples ? PrepareOptimumEntityLights() : 0", system);
+        Assert.Contains("OptimumConfig.EffectiveEntityShaderStateCache", system);
         Assert.Contains("!optimumEntityShaderCacheDisabled", system);
         Assert.Contains("OptimumEntityLightBatchSize = 256", system);
         Assert.Contains("OptimumEntityLightMinimumSamples = 4", system);

--- a/Optimum.Tests/fsr-pipeline-coverage-tests.cs
+++ b/Optimum.Tests/fsr-pipeline-coverage-tests.cs
@@ -77,9 +77,9 @@ public class FsrPipelineCoverageTests
         // rendering matches vanilla exactly - vanilla never sets these
         // TexParameter/SamplerParameter calls at all.
         Assert.Contains("if (ClientSettings.OptimumRenderScale >= 1.0f)", chunkRenderer);
-        Assert.Contains("MathF.Log2(ClientSettings.OptimumRenderScale)", chunkRenderer);
+        Assert.Contains("MathF.Log2(Math.Clamp(Vintagestory.API.Config.OptimumConfig.EffectiveRenderScale, 0.5f, 1.0f))", chunkRenderer);
         Assert.Contains("(TextureParameterName)34049, textureLodBias", chunkRenderer);
-        Assert.Contains("if (ClientSettings.OptimumRenderScale < 1.0f)", shaderRegistry);
+        Assert.Contains("if (OptimumConfig.EffectiveRenderScale < 1.0f)", shaderRegistry);
         Assert.Contains("(SamplerParameterName)34049, terrainLodBias", shaderRegistry);
         Assert.Contains("terrainTexLinear", shaderRegistry);
     }

--- a/Optimum.Tests/installer-path-normalization-tests.cs
+++ b/Optimum.Tests/installer-path-normalization-tests.cs
@@ -17,14 +17,14 @@ public class InstallerPathNormalizationTests
     {
         string script = Read("scripts/install-windows.ps1");
 
-        // The GUI click handler must detect a bare drive letter after TrimEnd
-        // and append a backslash BEFORE any GetFullPath call.
-        Assert.Contains("if ($dir -match '^[A-Za-z]:$')", script);
-        Assert.Contains("$dir = \"$dir\\\"", script);
+        // The shared normalizer must detect a bare drive letter and append a
+        // backslash before any GetFullPath call.
+        Assert.Contains("function Normalize-WindowsDirectoryPath", script);
+        Assert.Contains("if ($normalized -match '^[A-Za-z]:$')", script);
+        Assert.Contains("[System.IO.Path]::GetFullPath($normalized)", script);
 
-        // The normalization must appear BEFORE the VS-overlap GetFullPath check.
-        int normPos = script.IndexOf("if ($dir -match '^[A-Za-z]:$')");
-        int getFullPathPos = script.IndexOf("[System.IO.Path]::GetFullPath($dir)");
+        int normPos = script.IndexOf("if ($normalized -match '^[A-Za-z]:$')");
+        int getFullPathPos = script.IndexOf("[System.IO.Path]::GetFullPath($normalized)");
         Assert.True(normPos < getFullPathPos,
             "Drive letter normalization must precede the first GetFullPath($dir) call");
     }
@@ -34,8 +34,9 @@ public class InstallerPathNormalizationTests
     {
         string script = Read("scripts/install-windows.ps1");
 
-        // Invoke-OptimumBuild must also normalize bare drive letters from CLI args.
-        Assert.Contains("if ($InstallDir -match '^[A-Za-z]:$')", script);
+        // Invoke-OptimumBuild must normalize bare drive letters from CLI args
+        // through the shared helper.
+        Assert.Contains("$InstallDir = Normalize-WindowsDirectoryPath -Path $InstallDir -Name 'InstallDir'", script);
     }
 
     [Fact]
@@ -54,23 +55,30 @@ public class InstallerPathNormalizationTests
     {
         string script = Read("scripts/install-windows.ps1");
 
-        // Expected order in btnInstall click handler (search from the agree form):
-        // 1. Trim + TrimEnd
-        // 2. Empty check
-        // 3. Bare drive letter normalization
-        // 4. GetFullPath for VS overlap check
+        // The shared helper owns trim, drive-root normalization, and GetFullPath.
+        int helperPos = script.IndexOf("function Normalize-WindowsDirectoryPath");
+        int trimPos = script.IndexOf("$normalized = $Path.Trim()", helperPos);
+        int driveNorm = script.IndexOf("if ($normalized -match '^[A-Za-z]:$')", helperPos);
+        int fullPath = script.IndexOf("[System.IO.Path]::GetFullPath($normalized)", helperPos);
+
+        Assert.True(helperPos >= 0, "Path normalizer missing");
+        Assert.True(trimPos > helperPos, "Trim step missing in path normalizer");
+        Assert.True(driveNorm > trimPos, "Drive normalization must follow trim");
+        Assert.True(fullPath > driveNorm, "GetFullPath must follow drive normalization");
+
+        // The GUI click handler normalizes before its empty/root validation.
         int agreeForm = script.IndexOf("if ($agreeForm.ShowDialog()");
         Assert.True(agreeForm > 0, "Agree form dialog missing");
 
-        int trimPos = script.IndexOf("$dir = $script:txtDir.Text.Trim().TrimEnd", agreeForm);
-        int emptyCheck = script.IndexOf("if (-not $dir)", trimPos);
-        int driveNorm = script.IndexOf("if ($dir -match '^[A-Za-z]:$')", trimPos);
-        int fullPath = script.IndexOf("[System.IO.Path]::GetFullPath($dir)", trimPos);
+        int guiNormalizePos = script.IndexOf(
+            "$dir = Normalize-WindowsDirectoryPath -Path $script:txtDir.Text -Name 'InstallDir'",
+            agreeForm);
+        int emptyCheck = script.IndexOf("if (-not $dir)", guiNormalizePos);
+        int rootCheck = script.IndexOf("if (Test-FileSystemRoot -Path $dir)", guiNormalizePos);
 
-        Assert.True(trimPos > agreeForm, "Trim step missing after agree form");
-        Assert.True(emptyCheck > trimPos, "Empty check must follow trim");
-        Assert.True(driveNorm > emptyCheck, "Drive normalization must follow empty check");
-        Assert.True(fullPath > driveNorm, "GetFullPath must follow drive normalization");
+        Assert.True(guiNormalizePos > agreeForm, "Path normalization missing after agree form");
+        Assert.True(emptyCheck > guiNormalizePos, "Empty check must follow normalization");
+        Assert.True(rootCheck > emptyCheck, "Root validation must follow the empty check");
     }
 
     private static string Read(string relativePath)

--- a/Optimum.Tests/map-shader-reload-coverage-tests.cs
+++ b/Optimum.Tests/map-shader-reload-coverage-tests.cs
@@ -55,6 +55,19 @@ public sealed class MapShaderReloadCoverageTests
     }
 
     [Fact]
+    public void ExternalShaderCompatibilityDisablesThePageCacheFallback()
+    {
+        string config = Read("sources/VintagestoryApi/Config/OptimumConfig.cs");
+        string pageCache = Read("sources/VSEssentials/Systems/WorldMap/ChunkLayer/OptimumMapPageCache.cs");
+        string patch = PatchReader.ReadPatch(
+            "patches/runtime/VSEssentials/Vintagestory/GameContent/ChunkMapLayer.cs.patch");
+
+        Assert.Contains("EffectiveMapPageCache", config);
+        Assert.Contains("!OptimumConfig.EffectiveMapPageCache", pageCache);
+        Assert.Contains("OptimumConfig.EffectiveMapPageCache", patch);
+    }
+
+    [Fact]
     public void ChunkMapLayerRendersAllComponentsAfterInstancedPass()
     {
         string patch = PatchReader.ReadPatch(

--- a/patches/runtime/VSEssentials/Vintagestory/GameContent/ChunkMapLayer.cs.patch
+++ b/patches/runtime/VSEssentials/Vintagestory/GameContent/ChunkMapLayer.cs.patch
@@ -30,7 +30,7 @@ diff --git a/VSEssentials/Vintagestory/GameContent/ChunkMapLayer.cs b/VSEssentia
  			{
  				throw new Exception($"Cannot open {mapDbFilePath}, possibly corrupted. Please fix manually or delete this file to continue playing");
  			}
-+			if (OptimumConfig.MapPageCacheEnabled)
++			if (OptimumConfig.EffectiveMapPageCache)
 +			{
 +				pageCache = new OptimumMapPageCache(capi, api.World.SavegameIdentifier);
 +				if (OptimumConfig.MapPageCachePregen)
@@ -65,7 +65,7 @@ diff --git a/VSEssentials/Vintagestory/GameContent/ChunkMapLayer.cs b/VSEssentia
  	public override void OnMapOpenedClient()
  	{
  		colorAccurate = api.World.Config.GetAsBool("colorAccurateWorldmap") || capi.World.Player.Privileges.IndexOf("colorAccurateWorldmap") != -1;
-+		if (OptimumConfig.MapPageCacheEnabled && pageTextureArray == null)
++		if (OptimumConfig.EffectiveMapPageCache && pageTextureArray == null)
 +		{
 +			pageTextureArray = new OptimumMapTextureArray(OptimumConfig.MapPageCacheMaxLayers);
 +			pageRenderer = new OptimumMapPageRenderer(capi, pageTextureArray);
@@ -294,7 +294,7 @@ diff --git a/VSEssentials/Vintagestory/GameContent/ChunkMapLayer.cs b/VSEssentia
 +			centerChunkZ = (int)(sumZ / curVisibleChunks.Count);
 +		}
 +		(int centerPageX, int centerPageZ) = OptimumMapPageCache.ChunkToPage(centerChunkX, centerChunkZ);
-+		if (pageCache != null && OptimumConfig.MapPageCacheEnabled)
++		if (pageCache != null && OptimumConfig.EffectiveMapPageCache)
 +		{
 +			HashSet<long> queuedPages = new HashSet<long>();
 +			foreach (FastVec2i item in nowVisible)

--- a/sources/VSEssentials/Systems/OptimumStatus.cs
+++ b/sources/VSEssentials/Systems/OptimumStatus.cs
@@ -378,7 +378,7 @@ public class OptimumStatusModSystem : ModSystem
         api.Logger.Debug("[Optimum] God-rays sample limit: {0} ({1})",
             OptimumConfig.GodRaysSampleLimit,
             OptimumConfig.GodRaysSampleCapEnabled ? "cap" : "vanilla");
-        if (OptimumConfig.MapPageCacheEnabled)
+        if (OptimumConfig.EffectiveMapPageCache)
             api.Logger.Debug("[Optimum] Map page cache (FastMap): ON (maxLayers={0}, bc7={1})",
                 OptimumConfig.MapPageCacheMaxLayers, OptimumConfig.MapPageCacheBc7);
         if (OptimumConfig.AdaptiveRadiusEnabled)

--- a/sources/VSEssentials/Systems/WorldMap/ChunkLayer/OptimumMapPageCache.cs
+++ b/sources/VSEssentials/Systems/WorldMap/ChunkLayer/OptimumMapPageCache.cs
@@ -153,7 +153,7 @@ public sealed class OptimumMapPageCache : IDisposable
     /// </summary>
     public void WriteChunk(int chunkX, int chunkZ, int[] chunkPixels)
     {
-        if (!OptimumConfig.MapPageCacheEnabled || _disposed) return;
+        if (!OptimumConfig.EffectiveMapPageCache || _disposed) return;
         if (chunkPixels == null || chunkPixels.Length != GlobalConstants.ChunkSize * GlobalConstants.ChunkSize) return;
 
         var (pageX, pageZ) = ChunkToPage(chunkX, chunkZ);
@@ -202,7 +202,7 @@ public sealed class OptimumMapPageCache : IDisposable
     /// </summary>
     public bool TryReadPage(int pageX, int pageZ)
     {
-        if (!OptimumConfig.MapPageCacheEnabled || _disposed) return false;
+        if (!OptimumConfig.EffectiveMapPageCache || _disposed) return false;
 
         string path = GetPagePath(pageX, pageZ);
         if (!File.Exists(path)) return false;

--- a/sources/VintagestoryApi/Config/OptimumConfig.cs
+++ b/sources/VintagestoryApi/Config/OptimumConfig.cs
@@ -278,6 +278,9 @@ public static class OptimumConfig
     /// </summary>
     public static bool MapPageCacheEnabled = true;
 
+    public static bool EffectiveMapPageCache => MapPageCacheEnabled &&
+        !IsShaderFeatureDisabled("MapPageCache");
+
     /// <summary>
     /// Number of layers in the GL_TEXTURE_2D_ARRAY used for map page
     /// rendering. Each layer holds one 256x256 page. 128 covers most


### PR DESCRIPTION
## Summary

- Detect external shader assets and render hooks as incompatible with the map-page cache.
- Route map-cache creation, page-array setup, queueing, runtime reads and writes, and status reporting through `EffectiveMapPageCache`.
- Fail closed when the conservative compatibility report cannot be persisted.
- Add ZIP and scanner-to-config handoff coverage, include launcher tests in the Makefile and platform workflow, and refresh stale source-contract expectations exposed by the full suite.

Addresses #33.

## Verification

- `make build` - pass, 0 warnings and 0 errors.
- `make test` - pass: Optimum.Tests 660 passed, 34 skipped; Optimum.Launcher.Tests 21 passed.
- `make check` - pass with official `innoextract v1.13.0`.
- `make check-patches` - pass: 68 applied, 48 Cecil, 22 runtime donors compiled.
- `make check-compat` - pass: 0 cast divergences.
- `make check-shaders` - pass.
- `make patch-il` - pass: 126/126 required methods patched; API patch complete.
- `make package-linux` - pass: 603 MB package created.
- `make package-win` - pass in WSL with official `innoextract v1.13.0`: 672 MB ZIP created.
- Shell parsing, PowerShell parsing, and Linux prerequisite fixtures - pass.
- Native Windows workflow [32913234061](https://github.com/StratumServer/Optimum/actions/runs/32913234061) - pass: Bootstrap, Build, Check patches, Package, Optimum.Tests, and Optimum.Launcher.Tests.

## Notes

- The official [crazy-max/innoextract v1.13.0](https://github.com/crazy-max/innoextract/releases/tag/v1.13.0) binaries were verified against their published SHA-256 digests and installed for the WSL and Windows user environments. They support Inno Setup through 7.1.0, including the official 6.4.3 installer used by this repository.
- The fallback is conservative: external shader assets or hooks use vanilla map rendering, so unrelated hook mods may lose the optional FastMap optimization.
- The issue does not include a current client log or a reproducible Ancestral Bliss OpenGL trace. This PR addresses the map-cache shader-lifecycle path and does not claim an end-to-end client reproduction.
- Post-merge verification: merged as `ad644ec2f7c697d70501d57fb78ef915e492ccff` on 2026-08-26; no reviewer was requested.
