### PR TITLE
fix(patcher): tolerate corrupt debug symbols

### DIFF
--- a/Optimum.Patcher/AssemblyReader.cs
+++ b/Optimum.Patcher/AssemblyReader.cs
@@ -36,6 +36,20 @@ internal static class AssemblyReader
         {
             return ReadWithoutSymbols(path, parameters, ex);
         }
+        catch (Exception ex)
+        {
+            // A PDB can be present but unreadable: a truncated download, a
+            // wrong-format file, or disk corruption. Cecil reports missing and
+            // mismatched symbols with the two dedicated exceptions above, but a
+            // corrupt native or portable PDB surfaces the underlying reader's
+            // own exception (for example Microsoft.Cci.Pdb.PdbException), which
+            // lives in the Mono.Cecil.Pdb assembly and shares no public base
+            // with those two. Symbols are optional metadata, so any symbol-read
+            // failure falls back to a no-symbol read. A genuinely broken
+            // assembly still throws, because the retry below reads the same
+            // file without symbols.
+            return ReadWithoutSymbols(path, parameters, ex);
+        }
     }
 
     private static AssemblyDefinition ReadWithoutSymbols(

--- a/Optimum.Tests/pdb-symbol-fallback-tests.cs
+++ b/Optimum.Tests/pdb-symbol-fallback-tests.cs
@@ -88,7 +88,7 @@ public sealed class PdbSymbolFallbackTests
     }
 
     [Fact]
-    public void CorruptSymbolsStillFailTheRead()
+    public void CorruptSymbolsAreIgnoredAndAssemblyStillLoads()
     {
         string root = Path.Combine(Path.GetTempPath(), $"optimum-symbol-corrupt-{Guid.NewGuid():N}");
         string assemblyPath = Path.Combine(root, "assembly.dll");
@@ -100,16 +100,42 @@ public sealed class PdbSymbolFallbackTests
             File.WriteAllText(Path.ChangeExtension(assemblyPath, ".pdb"), "not a portable PDB");
 
             var parameters = new ReaderParameters { ReadSymbols = true };
-            Exception? error = Record.Exception(() =>
-            {
-                using AssemblyDefinition assembly = AssemblyReader.Read(
-                    assemblyPath,
-                    parameters,
-                    out _);
-            });
+            using AssemblyDefinition assembly = AssemblyReader.Read(
+                assemblyPath,
+                parameters,
+                out bool symbolsLoaded);
 
-            Assert.NotNull(error);
-            Assert.True(parameters.ReadSymbols);
+            Assert.False(symbolsLoaded);
+            Assert.False(parameters.ReadSymbols);
+            Assert.Equal("Optimum.Api.Contracts", assembly.Name.Name);
+        }
+        finally
+        {
+            DeleteFixture(root);
+        }
+    }
+
+    [Fact]
+    public void TruncatedSymbolsAreIgnoredAndAssemblyStillLoads()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"optimum-symbol-truncated-{Guid.NewGuid():N}");
+        string assemblyPath = Path.Combine(root, "assembly.dll");
+
+        try
+        {
+            Directory.CreateDirectory(root);
+            CopyOutputAssembly(assemblyPath, pdbName: null);
+            File.WriteAllBytes(Path.ChangeExtension(assemblyPath, ".pdb"), Array.Empty<byte>());
+
+            var parameters = new ReaderParameters { ReadSymbols = true };
+            using AssemblyDefinition assembly = AssemblyReader.Read(
+                assemblyPath,
+                parameters,
+                out bool symbolsLoaded);
+
+            Assert.False(symbolsLoaded);
+            Assert.False(parameters.ReadSymbols);
+            Assert.Equal("Optimum.Api.Contracts", assembly.Name.Name);
         }
         finally
         {


### PR DESCRIPTION
Addresses #46

## Summary

Issue #46 reports the installer failing during runtime patch validation with an unhandled exception in `Mono.Cecil.ModuleDefinition.ReadSymbols`. PR #47 handled missing and mismatched PDB files, but a corrupt or truncated PDB still crashes the patcher because its reader exception type is not one of the two the fallback catches.

This PR extends `AssemblyReader.Read` so any symbol-read failure falls back to a no-symbol read. Debug symbols stay optional metadata, matching how the launcher and cache already treat output PDBs.

## Root cause

`AssemblyReader.Read` caught only `SymbolsNotFoundException` (missing PDB) and `SymbolsNotMatchingException` (mismatched PDB). A corrupt native PDB throws `Microsoft.Cci.Pdb.PdbException`, an internal `IOException` in the `Mono.Cecil.Pdb` assembly with no shared public base with the two caught types. That exception escaped `Read` and aborted the `Optimum.Patcher` subprocess before any patch applied.

I reproduced it against a pristine `VintagestoryLib.vanilla.dll` with a garbage PDB beside it. The patcher aborts with `Microsoft.Cci.Pdb.PdbException: The PDB file is not recognized as a Windows PDB file` from `ReadSymbols`, the same frame the issue reports. On Linux the runtime surfaces this as SIGABRT (exit 134); on Windows the same unhandled exception is the -532462766 (0xE0434352) exit code the reporter saw.

## Fix

`AssemblyReader.Read` now retries without symbols on any exception while `ReadSymbols` is enabled. The two existing specific catches stay for the documented cases, and a final general catch covers unreadable or truncated PDBs. If the assembly itself is broken, the no-symbol retry reads the same file and re-throws, so genuine assembly errors still surface.

## Tests

Renamed `CorruptSymbolsStillFailTheRead` to `CorruptSymbolsAreIgnoredAndAssemblyStillLoads` and added `TruncatedSymbolsAreIgnoredAndAssemblyStillLoads` for a zero-byte PDB. Both assert the assembly still loads, symbols are reported as not loaded, and symbol loading is disabled after the fallback.

## Validation

- Focused PDB suite: 6 passed.
- Baseline reproduction (garbage PDB): crashed before the fix; after the fix it logs the warning and completes the full engine transplant (126 of 126 required methods patched, exit 0).
- `dotnet build VintageStory.slnx -c Release`: 0 warnings, 0 errors.
- `Optimum.Tests`: 663 passed, 34 skipped, 0 failed.
- `Optimum.Launcher.Tests`: 21 passed, 0 failed.

The change touches optional debug metadata only and does not change the patched runtime IL.
