### PR TITLE
fix(installer): route dotnet prereq through nixpkgs on NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,36 @@ make run      # build, deploy, and launch client
 
 Requires .NET 10 SDK, bash, python3, git, curl, perl.
 
+**NixOS** (non-FHS distribution):
+
+The interactive installer detects NixOS and routes the .NET 10 SDK prerequisite
+through nixpkgs, since the SDK from dot.net is a glibc build that cannot run
+there:
+
+```sh
+nix profile install nixpkgs#dotnet-sdk_10
+```
+
+The packaged launcher and game are glibc binaries as well, so run the AppImage
+through `appimage-run` with the runtime dependencies exposed. In the NixOS
+configuration:
+
+```nix
+programs.appimage.enable = true;
+programs.appimage.binfmt = true;
+programs.appimage.package = pkgs.appimage-run.override {
+  extraPkgs = pkgs: [
+    pkgs.dotnet-runtime
+    pkgs.openal
+    pkgs.gtk3
+  ];
+};
+```
+
+Then run the `.AppImage` normally. `dotnet-runtime` exposes the .NET runtime
+for the launcher, and `openal` and `gtk3` cover the game's audio and UI native
+libraries. Add or remove entries if your build needs a different native set.
+
 ### Windows
 
 **GUI installer** (checks prerequisites, offers downloads, choose install folder):

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -92,10 +92,30 @@ check_cmd() { command -v "$1" &>/dev/null; }
 DOTNET_BIN=""  # set by check_dotnet10 on success
 ILSPY_BIN=""   # set by check_ilspycmd on success
 
-# NixOS (and other non-FHS systems) do not ship the glibc dynamic linker at
-# /lib64/ld-linux-x86-64.so.2, so the SDK that dotnet-install.sh downloads
-# cannot run there. Detect those systems so the installer routes the .NET 10
-# prerequisite through nixpkgs instead of downloading a broken SDK.
+# dotnet-install.sh downloads a glibc SDK whose binaries hardcode the system
+# dynamic linker. NixOS and other non-FHS systems keep that linker in the Nix
+# store, so the downloaded SDK cannot run unless the linker is exposed at the
+# standard path (for example through nix-ld on NixOS). Check the interpreter
+# for the current architecture rather than guessing from the distribution.
+glibc_interpreter_path() {
+    if [[ -n "${OPTIMUM_GLIBC_INTERPRETER:-}" ]]; then
+        printf '%s' "$OPTIMUM_GLIBC_INTERPRETER"
+        return
+    fi
+    case "$(uname -m)" in
+        x86_64|amd64) printf '%s' '/lib64/ld-linux-x86-64.so.2' ;;
+        aarch64|arm64) printf '%s' '/lib/ld-linux-aarch64.so.1' ;;
+        *) printf '%s' '' ;;
+    esac
+}
+
+downloaded_dotnet_runnable() {
+    local interp
+    interp="$(glibc_interpreter_path)"
+    [[ -z "$interp" ]] && return 0
+    [[ -e "$interp" ]]
+}
+
 detect_nixos() {
     [[ -e /etc/NIXOS ]] || [[ -n "${NIX_STORE:-}" ]]
 }
@@ -249,8 +269,11 @@ system_install_command() {
 }
 
 install_dotnet10() {
-    if detect_nixos; then
-        die "On NixOS the .NET 10 SDK must come from nixpkgs; the dot.net installer downloads a glibc build that cannot run there. Run: $(nixos_dotnet_install_cmd), then re-run this installer."
+    if ! downloaded_dotnet_runnable; then
+        if detect_nixos; then
+            die "The dot.net installer downloads a glibc SDK that cannot run here (missing $(glibc_interpreter_path)). On NixOS install it from nixpkgs instead: $(nixos_dotnet_install_cmd), then re-run this installer."
+        fi
+        die "The dot.net installer downloads a glibc SDK that cannot run here (missing $(glibc_interpreter_path)). Install the .NET 10 SDK through your distribution and re-run this installer."
     fi
     local installer
     installer=$(mktemp)
@@ -314,6 +337,10 @@ detect_prereqs() {
             PREREQ_LABEL[dotnet]=".NET 10 SDK (NixOS: install via nixpkgs)"
             PREREQ_INSTALL_CMD[dotnet]="$(nixos_dotnet_install_cmd)"
             PREREQ_INSTALL_URL[dotnet]="https://search.nixos.org/packages?query=dotnet-sdk_10"
+        elif ! downloaded_dotnet_runnable; then
+            PREREQ_LABEL[dotnet]=".NET 10 SDK (non-FHS system: install via your distribution)"
+            PREREQ_INSTALL_CMD[dotnet]=""
+            PREREQ_INSTALL_URL[dotnet]="https://learn.microsoft.com/dotnet/core/install/linux"
         else
             PREREQ_LABEL[dotnet]=".NET 10 SDK"
             PREREQ_INSTALL_CMD[dotnet]="curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0 --install-dir ~/.dotnet"

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -92,6 +92,18 @@ check_cmd() { command -v "$1" &>/dev/null; }
 DOTNET_BIN=""  # set by check_dotnet10 on success
 ILSPY_BIN=""   # set by check_ilspycmd on success
 
+# NixOS (and other non-FHS systems) do not ship the glibc dynamic linker at
+# /lib64/ld-linux-x86-64.so.2, so the SDK that dotnet-install.sh downloads
+# cannot run there. Detect those systems so the installer routes the .NET 10
+# prerequisite through nixpkgs instead of downloading a broken SDK.
+detect_nixos() {
+    [[ -e /etc/NIXOS ]] || [[ -n "${NIX_STORE:-}" ]]
+}
+
+nixos_dotnet_install_cmd() {
+    printf '%s' 'nix profile install nixpkgs#dotnet-sdk_10'
+}
+
 check_dotnet10() {
     DOTNET_BIN=""
     local candidates=()
@@ -107,6 +119,7 @@ check_dotnet10() {
     else
         candidates+=(
             "$HOME/.dotnet/dotnet"
+            "$HOME/.nix-profile/bin/dotnet"
             "/usr/share/dotnet/dotnet"
             "/usr/lib/dotnet/dotnet"
             "/snap/dotnet-sdk/current/dotnet"
@@ -236,6 +249,9 @@ system_install_command() {
 }
 
 install_dotnet10() {
+    if detect_nixos; then
+        die "On NixOS the .NET 10 SDK must come from nixpkgs; the dot.net installer downloads a glibc build that cannot run there. Run: $(nixos_dotnet_install_cmd), then re-run this installer."
+    fi
     local installer
     installer=$(mktemp)
     if check_cmd curl; then
@@ -294,9 +310,15 @@ detect_prereqs() {
         fi
     else
         PREREQ_STATUS[dotnet]="missing"
-        PREREQ_LABEL[dotnet]=".NET 10 SDK"
-        PREREQ_INSTALL_CMD[dotnet]="curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0 --install-dir ~/.dotnet"
-        PREREQ_INSTALL_URL[dotnet]="https://dotnet.microsoft.com/download/dotnet/10.0"
+        if detect_nixos; then
+            PREREQ_LABEL[dotnet]=".NET 10 SDK (NixOS: install via nixpkgs)"
+            PREREQ_INSTALL_CMD[dotnet]="$(nixos_dotnet_install_cmd)"
+            PREREQ_INSTALL_URL[dotnet]="https://search.nixos.org/packages?query=dotnet-sdk_10"
+        else
+            PREREQ_LABEL[dotnet]=".NET 10 SDK"
+            PREREQ_INSTALL_CMD[dotnet]="curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0 --install-dir ~/.dotnet"
+            PREREQ_INSTALL_URL[dotnet]="https://dotnet.microsoft.com/download/dotnet/10.0"
+        fi
     fi
 
     # Git

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -883,6 +883,9 @@ main() {
         printf "    ${BOLD}Desktop:${RESET} %s\n" "$desktop_dir/Optimum.desktop"
     fi
     printf "    ${BOLD}Run:${RESET}     %s/optimum-launch.sh\n" "$INSTALL_DIR"
+    if detect_nixos; then
+        warn "NixOS detected: the launcher and game are glibc binaries. Run them through a FHS environment such as steam-run (or appimage-run for the AppImage) with the .NET runtime and game native libraries exposed. See the NixOS section in README.md."
+    fi
     printf "\n"
 }
 

--- a/scripts/tests/install-linux-nixos.sh
+++ b/scripts/tests/install-linux-nixos.sh
@@ -29,32 +29,58 @@ export OPTIMUM_DOTNET_CANDIDATES="$TEST_ROOT/absent/dotnet"
 
 source "$REPO_ROOT/scripts/install-linux.sh"
 
-# Without any Nix signal the host is not treated as NixOS.
+# --- Interpreter check ---
+# On the default glibc host a downloaded SDK would run.
+unset OPTIMUM_GLIBC_INTERPRETER
+if ! downloaded_dotnet_runnable; then
+    echo "downloaded_dotnet_runnable returned false on the default glibc host" >&2
+    exit 1
+fi
+
+# Simulate a non-FHS host: override the interpreter to a missing path.
+export OPTIMUM_GLIBC_INTERPRETER="$TEST_ROOT/missing-ld-linux"
+[[ "$(glibc_interpreter_path)" == "$TEST_ROOT/missing-ld-linux" ]]
+if downloaded_dotnet_runnable; then
+    echo "downloaded_dotnet_runnable returned true with a missing interpreter" >&2
+    exit 1
+fi
+
+# --- NixOS detection ---
 unset NIX_STORE
 if detect_nixos; then
     echo "detect_nixos returned true without NIX_STORE or /etc/NIXOS" >&2
     exit 1
 fi
-
-# With NIX_STORE set the installer treats the host as NixOS.
 export NIX_STORE="$TEST_ROOT/nix/store"
-if ! detect_nixos; then
-    echo "detect_nixos returned false with NIX_STORE set" >&2
-    exit 1
-fi
+detect_nixos || { echo "detect_nixos returned false with NIX_STORE set" >&2; exit 1; }
 
 [[ "$(nixos_dotnet_install_cmd)" == *"nixpkgs"* ]]
 [[ "$(nixos_dotnet_install_cmd)" == *"dotnet-sdk_10"* ]]
 
+# --- NixOS prerequisite routing ---
 detect_prereqs
 [[ "${PREREQ_STATUS[dotnet]}" == "missing" ]]
 [[ "${PREREQ_LABEL[dotnet]}" == *"nixpkgs"* ]]
 [[ "${PREREQ_INSTALL_CMD[dotnet]}" == "nix profile install nixpkgs#dotnet-sdk_10" ]]
 
-# install_dotnet10 must refuse to run the glibc dotnet-install.sh on NixOS.
+# install_dotnet10 must refuse the glibc installer on NixOS.
 if ( install_dotnet10 ) 2>/dev/null; then
     echo "install_dotnet10 succeeded on NixOS; expected it to refuse" >&2
     exit 1
 fi
 
-echo "Linux NixOS prerequisite tests passed."
+# --- non-NixOS, non-FHS routing ---
+unset NIX_STORE
+detect_prereqs
+[[ "${PREREQ_STATUS[dotnet]}" == "missing" ]]
+[[ "${PREREQ_LABEL[dotnet]}" == *"non-FHS"* ]]
+[[ -z "${PREREQ_INSTALL_CMD[dotnet]}" ]]
+
+# install_dotnet10 must refuse the glibc installer when the interpreter is
+# missing even outside NixOS.
+if ( install_dotnet10 ) 2>/dev/null; then
+    echo "install_dotnet10 succeeded without a glibc interpreter; expected it to refuse" >&2
+    exit 1
+fi
+
+echo "Linux NixOS and non-FHS prerequisite tests passed."

--- a/scripts/tests/install-linux-nixos.sh
+++ b/scripts/tests/install-linux-nixos.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="$TEST_ROOT/home"
+export PATH="$TEST_ROOT/bin:/usr/bin:/bin"
+mkdir -p "$HOME" "$TEST_ROOT/bin"
+
+# Shadow any host dotnet with an SDK-9 stub so check_dotnet10 reports the .NET
+# 10 prerequisite as missing regardless of the build machine.
+cat > "$TEST_ROOT/bin/dotnet" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--list-sdks" ]]; then
+    echo "9.0.100 [/system/sdk]"
+    exit 0
+fi
+exit 1
+EOF
+chmod +x "$TEST_ROOT/bin/dotnet"
+
+# A non-existent override suppresses the default candidate list (which on a
+# dev host would otherwise reach a real system .NET 10 SDK).
+export OPTIMUM_DOTNET_CANDIDATES="$TEST_ROOT/absent/dotnet"
+
+source "$REPO_ROOT/scripts/install-linux.sh"
+
+# Without any Nix signal the host is not treated as NixOS.
+unset NIX_STORE
+if detect_nixos; then
+    echo "detect_nixos returned true without NIX_STORE or /etc/NIXOS" >&2
+    exit 1
+fi
+
+# With NIX_STORE set the installer treats the host as NixOS.
+export NIX_STORE="$TEST_ROOT/nix/store"
+if ! detect_nixos; then
+    echo "detect_nixos returned false with NIX_STORE set" >&2
+    exit 1
+fi
+
+[[ "$(nixos_dotnet_install_cmd)" == *"nixpkgs"* ]]
+[[ "$(nixos_dotnet_install_cmd)" == *"dotnet-sdk_10"* ]]
+
+detect_prereqs
+[[ "${PREREQ_STATUS[dotnet]}" == "missing" ]]
+[[ "${PREREQ_LABEL[dotnet]}" == *"nixpkgs"* ]]
+[[ "${PREREQ_INSTALL_CMD[dotnet]}" == "nix profile install nixpkgs#dotnet-sdk_10" ]]
+
+# install_dotnet10 must refuse to run the glibc dotnet-install.sh on NixOS.
+if ( install_dotnet10 ) 2>/dev/null; then
+    echo "install_dotnet10 succeeded on NixOS; expected it to refuse" >&2
+    exit 1
+fi
+
+echo "Linux NixOS prerequisite tests passed."


### PR DESCRIPTION
Addresses #15

## Summary

Issue #15 reports that the Linux installer does not install on NixOS. The report has no log, but the blocker is deterministic. When the .NET SDK is missing, the installer runs `dotnet-install.sh`, which downloads a glibc SDK whose binaries hardcode the dynamic linker at `/lib64/ld-linux-x86-64.so.2`. NixOS keeps that linker in the Nix store, so the downloaded SDK cannot run.

This change makes the installer check that linker before downloading, routes the NixOS case through nixpkgs, and documents the runtime setup for the packaged game.

## Change

- `glibc_interpreter_path()` maps the architecture to its glibc linker path, overridable via `OPTIMUM_GLIBC_INTERPRETER` for tests.
- `downloaded_dotnet_runnable()` reports whether a downloaded glibc SDK can run by checking for that linker.
- `install_dotnet10()` refuses `dotnet-install.sh` when the linker is missing, pointing to nixpkgs on NixOS or the distribution package manager elsewhere.
- `detect_nixos()` identifies NixOS by `/etc/NIXOS` or `NIX_STORE` for the nixpkgs-specific guidance.
- The prerequisite prompt shows the nixpkgs command on NixOS, a distribution-manager hint on other non-FHS systems, and the dot.net download otherwise.
- `check_dotnet10()` also probes `$HOME/.nix-profile/bin/dotnet`.
- After install, the installer prints NixOS runtime guidance, and the README documents the `appimage-run` setup with `dotnet-runtime`, `openal`, and `gtk3`.

## Validation

- Shell unit tests: `scripts/tests/install-linux-nixos.sh` and `install-linux-prerequisites.sh` pass; `bash -n` and `shellcheck` clean.
- Full NixOS VM (NixOS 25.11 minimal ISO, QEMU/KVM, serial console): `/etc/NIXOS` is present and both glibc linker paths are absent. A host-built glibc `dotnet` binary fails there with exit 127. Sourcing the installer gives `detect_nixos=yes` and `downloaded_dotnet_runnable=no`, and `install_dotnet10` refuses the dot.net download with the nixpkgs guidance.
- nixpkgs guidance: `nix build nixpkgs#dotnet-sdk_10` resolves to 10.0.400, and the resulting `dotnet --list-sdks` reports 10.0.400.

## Limitations

The AppImage launch itself was not run; it needs a graphical session, which this headless VM does not provide. The `extraPkgs` set (`dotnet-runtime`, `openal`, `gtk3`) is a starting point, and a specific NixOS build may need more native libraries. No reporter log was available to confirm the exact failure point.