### PR TITLE
fix(worldgen): detect Harmony patches on closures in safety gate

### DIFF
--- a/Optimum.Tests/worldgen-mod-shaped-fixture-tests.cs
+++ b/Optimum.Tests/worldgen-mod-shaped-fixture-tests.cs
@@ -46,6 +46,23 @@ public sealed class WorldgenModShapedFixtureTests
         Assert.False(OptimumWorldgenSafetyGate.IsKnownSafeAssembly(assemblyName));
     }
 
+    [Fact]
+    public async Task StaticScratchFieldsRaceAcrossColumnsLikeTerraPretyCoastmap()
+    {
+        // TerraPrety's transpiler injects initCoastmapForChunk into GenTerra.generate,
+        // which writes static CoastMap.coastMap* fields read later by getSalinityFor.
+        // A static-scratch generator reproduces that shape: parallel columns corrupt
+        // the scratch and diverge from the serial hash.
+        int[] columns = CreateColumns(24);
+        var serial = new StaticScratchGenerator(42424242);
+        int serialHash = Hash(serial.GenerateSerial(columns));
+
+        var parallel = new StaticScratchGenerator(42424242);
+        int parallelHash = Hash(await parallel.GenerateParallel(columns, 3));
+
+        Assert.NotEqual(serialHash, parallelHash);
+    }
+
     private static int[] CreateColumns(int count)
     {
         var columns = new int[count];
@@ -155,6 +172,61 @@ public sealed class WorldgenModShapedFixtureTests
             workspace.ColumnResults[0] = Mix(seed, column);
             workspace.LandformCache[column] = workspace.ColumnResults[0];
             return workspace.LandformCache[column];
+        }
+    }
+
+    private sealed class StaticScratchGenerator
+    {
+        private static int sCoastUpLeft;
+        private static int sCoastUpRight;
+        private static int sCoastBotLeft;
+        private static int sCoastBotRight;
+
+        private readonly int seed;
+
+        public StaticScratchGenerator(int seed)
+        {
+            this.seed = seed;
+        }
+
+        public int[] GenerateSerial(IReadOnlyList<int> columns)
+        {
+            var results = new int[columns.Count];
+            for (int i = 0; i < columns.Count; i++) results[i] = Generate(columns[i], null);
+            return results;
+        }
+
+        public async Task<int[]> GenerateParallel(IReadOnlyList<int> columns, int workerCount)
+        {
+            var results = new int[columns.Count];
+            for (int start = 0; start < columns.Count; start += workerCount)
+            {
+                int count = Math.Min(workerCount, columns.Count - start);
+                using var barrier = new Barrier(count);
+                var tasks = new Task[count];
+                for (int offset = 0; offset < count; offset++)
+                {
+                    int index = start + offset;
+                    tasks[offset] = Task.Run(() => results[index] = Generate(columns[index], barrier));
+                }
+                await Task.WhenAll(tasks);
+            }
+            return results;
+        }
+
+        private int Generate(int column, Barrier? barrier)
+        {
+            // Phase 1: write static scratch (like initCoastmapForChunk).
+            sCoastUpLeft = Mix(seed, column);
+            sCoastUpRight = Mix(seed, column + 1);
+            sCoastBotLeft = Mix(seed, column + 2);
+            sCoastBotRight = Mix(seed, column + 3);
+
+            // Force interleaving so another column overwrites the scratch before read-back.
+            barrier?.SignalAndWait();
+
+            // Phase 2: read static scratch back (like getSalinityFor).
+            return sCoastUpLeft ^ sCoastUpRight ^ sCoastBotLeft ^ sCoastBotRight;
         }
     }
 

--- a/Optimum.Tests/worldgen-r1-workspace-patch-contract-tests.cs
+++ b/Optimum.Tests/worldgen-r1-workspace-patch-contract-tests.cs
@@ -78,4 +78,19 @@ public sealed class WorldgenR1WorkspacePatchContractTests
         Assert.Contains("\"TryAcquireOptimumWorldgenFootprint\"", patcher);
         Assert.Contains("\"optimumUnloadGenLeases\"", patcher);
     }
+
+    [Fact]
+    public void SafetyGateDetectsPatchesOnMethodsTheHandlerCallsNotJustTheHandler()
+    {
+        string source = PatchReader.ReadPatch("patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch");
+
+        // A mod can patch a method the registered handler calls (GenTerra.generate)
+        // or a compiler-generated closure the handler invokes (GenTerra.<>c__DisplayClass34_0)
+        // without patching the handler method itself. The safety gate must scan the
+        // declaring type and its nested types, not just Harmony.GetPatchInfo(handler.Method).
+        Assert.Contains("IsWorldgenHandlerHarmonyPatched", source);
+        Assert.Contains("handlerMethod.DeclaringType", source);
+        Assert.Contains("declaringType.GetMethods", source);
+        Assert.Contains("declaringType.GetNestedTypes", source);
+    }
 }

--- a/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
-index 159b06c..22b6600 100644
+index 159b06c..5e50b61 100644
 --- a/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 +++ b/VintagestoryLib/Vintagestory.Server/ServerSystemSupplyChunks.cs
 @@ -1,9 +1,13 @@
@@ -218,7 +218,7 @@ index 159b06c..22b6600 100644
  		return false;
  	}
  
-@@ -419,57 +532,286 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -419,57 +532,328 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			return stage == 0;
  		}
  		bool num = CanGenerateChunkColumn(chunkRequest);
@@ -365,15 +365,7 @@ index 159b06c..22b6600 100644
 -				requestedChunkColumn.FlagToRequeue();
 +				string assemblyName = handler?.Method?.DeclaringType?.Assembly?.GetName().Name;
 +				bool foreign = !OptimumWorldgenSafetyGate.IsKnownSafeAssembly(assemblyName);
-+				bool harmonyPatched;
-+				try
-+				{
-+					harmonyPatched = handler?.Method != null && Harmony.GetPatchInfo(handler.Method)?.Owners?.Count > 0;
-+				}
-+				catch
-+				{
-+					harmonyPatched = true;
-+				}
++				bool harmonyPatched = IsWorldgenHandlerHarmonyPatched(handler);
 +
 +				if (pass == (int)EnumWorldGenPass.Terrain && !IsWorldgenHandlerAllowedForParallelPass(pass, handler))
 +				{
@@ -399,6 +391,65 @@ index 159b06c..22b6600 100644
 +		}
 +
 +		return eligible;
++	}
++
++	private bool IsWorldgenHandlerHarmonyPatched(ChunkColumnGenerationDelegate handler)
++	{
++		MethodInfo handlerMethod = handler?.Method;
++		if (handlerMethod == null)
++		{
++			return false;
++		}
++		try
++		{
++			// A mod can patch a method the registered handler calls (for example
++			// GenTerra.generate) or a compiler-generated closure the handler invokes
++			// (for example GenTerra.<>c__DisplayClass34_0) instead of the handler
++			// method itself. Checking only the handler method leaves those patches
++			// invisible, so the pass cap stays raised while the patched body is not
++			// safe to run concurrently. Scan the declaring type and its nested types
++			// to catch both shapes.
++			if (Harmony.GetPatchInfo(handlerMethod)?.Owners?.Count > 0)
+ 			{
+-				if (ensurePrettyNeighbourhood(requestedChunkColumn))
++				return true;
++			}
++			Type declaringType = handlerMethod.DeclaringType;
++			if (declaringType == null)
++			{
++				return false;
++			}
++			foreach (MethodInfo method in declaringType.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
++			{
++				if (Harmony.GetPatchInfo(method)?.Owners?.Count > 0)
+ 				{
+-					num = requestedChunkColumn.creationTime;
+-					chunkColumnLoadRequest = requestedChunkColumn;
++					return true;
+ 				}
+-				else
++			}
++			foreach (Type nested in declaringType.GetNestedTypes(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
++			{
++				foreach (MethodInfo method in nested.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+ 				{
+-					requestedChunkColumn.FlagToRequeue();
++					if (Harmony.GetPatchInfo(method)?.Owners?.Count > 0)
++					{
++						return true;
++					}
+ 				}
+ 			}
+ 		}
+-		if (chunkColumnLoadRequest != null)
++		catch
+ 		{
+-			PopulateChunk(chunkColumnLoadRequest);
+-			return 1;
++			return true;
+ 		}
+-		return 0;
++		return false;
 +	}
 +
 +	private bool IsWorldgenHandlerAllowedForParallelPass(int pass, ChunkColumnGenerationDelegate handler)
@@ -432,16 +483,12 @@ index 159b06c..22b6600 100644
 +		if (targetType != null)
 +		{
 +			lock (optimumGeneratorLockRegistry)
- 			{
--				if (ensurePrettyNeighbourhood(requestedChunkColumn))
++			{
 +				if (!optimumGeneratorTypeLocks.TryGetValue(targetType, out Lock targetLock))
- 				{
--					num = requestedChunkColumn.creationTime;
--					chunkColumnLoadRequest = requestedChunkColumn;
++				{
 +					targetLock = new Lock();
 +					optimumGeneratorTypeLocks[targetType] = targetLock;
- 				}
--				else
++				}
 +				return targetLock;
 +			}
 +		}
@@ -452,15 +499,13 @@ index 159b06c..22b6600 100644
 +			lock (optimumGeneratorLockRegistry)
 +			{
 +				if (!optimumGeneratorMethodLocks.TryGetValue(method, out Lock methodLock))
- 				{
--					requestedChunkColumn.FlagToRequeue();
++				{
 +					methodLock = new Lock();
 +					optimumGeneratorMethodLocks[method] = methodLock;
- 				}
++				}
 +				return methodLock;
- 			}
- 		}
--		if (chunkColumnLoadRequest != null)
++			}
++		}
 +
 +		return optimumGeneratorLockRegistry;
 +	}
@@ -472,13 +517,10 @@ index 159b06c..22b6600 100644
 +			return;
 +		}
 +		if (IsWorldgenHandlerDirectlySafe(forPass, handler))
- 		{
--			PopulateChunk(chunkColumnLoadRequest);
--			return 1;
++		{
 +			handler(chunkRequest);
 +			return;
- 		}
--		return 0;
++		}
 +		Lock generatorLock = GetWorldgenGeneratorLock(handler);
 +		lock (generatorLock)
 +		{
@@ -524,7 +566,7 @@ index 159b06c..22b6600 100644
  	public bool CanGenerateChunkColumn(ChunkColumnLoadRequest chunkRequest)
  	{
  		if (chunkRequest.CurrentIncompletePass_AsInt >= chunkRequest.untilPass || !ensurePrettyNeighbourhood(chunkRequest))
-@@ -931,32 +1273,112 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -931,32 +1315,112 @@ internal class ServerSystemSupplyChunks : ServerSystem
  	internal ServerChunk[] TryLoadChunkColumn(ChunkColumnLoadRequest chunkRequest)
  	{
  		int chunkMapSizeY = server.WorldMap.ChunkMapSizeY;
@@ -653,7 +695,7 @@ index 159b06c..22b6600 100644
  		if (requiresSetEmptyFlag)
  		{
  			foreach (ServerChunk serverChunk in array)
-@@ -1038,10 +1460,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1038,10 +1502,11 @@ internal class ServerSystemSupplyChunks : ServerSystem
  	}
  
  	public void InitWorldgenAndSpawnChunks()
@@ -665,7 +707,7 @@ index 159b06c..22b6600 100644
  		{
  			storyChunkSpawnEvents = new string[15]
  			{
-@@ -1278,10 +1701,15 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1278,10 +1743,15 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		}
  		long num3 = Environment.TickCount + 12000;
  		ServerMain.Logger.VerboseDebug("Starting area loading/generation: columns " + blockingRequestsRemaining + ", total queue length " + chunkthread.requestedChunkColumns.Count);
@@ -681,7 +723,7 @@ index 159b06c..22b6600 100644
  			{
  				break;
  			}
-@@ -1299,34 +1727,57 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1299,34 +1769,57 @@ internal class ServerSystemSupplyChunks : ServerSystem
  					ServerMain.Logger.StoryEvent("...");
  				}
  				storyEventPrints++;
@@ -741,7 +783,7 @@ index 159b06c..22b6600 100644
  				ServerMain.Logger.Error("Attempting to force generate chunk columns from " + chunkX1 + "," + chunkZ1 + " to " + chunkX2 + "," + chunkZ2);
  				ServerMain.Logger.Error(chunkthread.additionalWorldGenThreadsCount + " additional worldgen threads active, number of 'undone' chunks is " + blockingRequestsRemaining);
  				foreach (ChunkColumnLoadRequest requestedChunkColumn3 in chunkthread.requestedChunkColumns)
-@@ -1340,12 +1791,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1340,12 +1833,16 @@ internal class ServerSystemSupplyChunks : ServerSystem
  				throw new Exception("Somehow worldgen has become stuck in an endless loop, please report this as a bug!  Additional data in the server-main log");
  			}
  		}
@@ -759,7 +801,7 @@ index 159b06c..22b6600 100644
  		try
  		{
  			if (server.Config.SkipEveryChunkRow > 0 && chunkRequest.chunkX % (server.Config.SkipEveryChunkRow + server.Config.SkipEveryChunkRowWidth) < server.Config.SkipEveryChunkRowWidth)
-@@ -1375,29 +1830,80 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1375,29 +1872,80 @@ internal class ServerSystemSupplyChunks : ServerSystem
  			chunkRequest.MapChunk.DirtyForSaving = true;
  		}
  		finally
@@ -842,7 +884,7 @@ index 159b06c..22b6600 100644
  					break;
  				}
  			}
-@@ -1507,43 +2013,95 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1507,43 +2055,95 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		ServerMain.Logger.VerboseDebug("Incomplete chunks stored and wiped.");
  	}
  
@@ -880,7 +922,7 @@ index 159b06c..22b6600 100644
 -			if (chunkthread.requestedChunkColumns.Count > 0 && (!server.Suspended || server.RunPhase == EnumServerRunPhase.WorldReady))
 +			// Automatic mode may raise the cap after spawn. Exact mode skips this path.
 +			if (!chunkthread.optimumExactWorldgenWorkerMode && Volatile.Read(ref optimumPostSpawnRaised) == 0 && server.RunPhase == EnumServerRunPhase.RunGame)
- 			{
++			{
 +				if (Interlocked.CompareExchange(ref optimumPostSpawnRaised, 1, 0) == 0)
 +				{
 +					int maxCeiling = OptimumConfig.GetWorldgenWorkerCeiling(Environment.ProcessorCount, server.ReducedServerThreads);
@@ -902,7 +944,7 @@ index 159b06c..22b6600 100644
 +			}
 +
 +			if (OptimumWorldgenWorkersActive() && chunkthread.requestedChunkColumns.Count > 0 && (!server.Suspended || server.RunPhase == EnumServerRunPhase.WorldReady))
-+			{
+ 			{
 +				Interlocked.Increment(ref optimumWorldgenDispatchesInFlight);
  				try
  				{
@@ -942,7 +984,7 @@ index 159b06c..22b6600 100644
  			Thread.Sleep(1);
  		}
  		BlockAccessorWorldGen.ThreadDispose();
-@@ -1554,13 +2112,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
+@@ -1554,13 +2154,23 @@ internal class ServerSystemSupplyChunks : ServerSystem
  		BlockAccessorWorldGen.ThreadDispose();
  	}
  


### PR DESCRIPTION
Addresses #31

## Summary

Issue #31 reports all-rock terrain and delayed chunks with worldgen mods. One concrete lead, the unload/footprint race, was already fixed in #50. This PR closes a second, source-verified gap in the worldgen safety gate.

The safety gate decides whether Optimum can run the Terrain pass across several columns at once. It drops to serial when it finds a foreign assembly or a Harmony patch on a registered handler. But it only checked `Harmony.GetPatchInfo(handler.Method)`. A mod that patches a method the handler calls, or a compiler-generated closure the handler invokes, stays invisible, so the Terrain cap stays raised while the patched body is not safe to run concurrently.

## Root cause

TerraPrety's `ContinentalUpheavalPatches` patches `GenTerra.generate` with a transpiler that injects a call to `initCoastmapForChunk`, which writes the static `CoastMap.coastMapUpLeft/UpRight/BotLeft/BotRight` fields. `MoreContinentalUpheavalPatches` patches `GenTerra.<>c__DisplayClass34_0.<generate>b__0` to read those fields back. In vanilla this is safe because one column runs at a time. With Optimum's Terrain cap at 3, three columns race on those static fields, and the coast and ocean data for one column can be read against another column's values.

The safety gate missed this because TerraPrety patches `GenTerra.generate` and the closure, not the registered handler `GenTerra.OnChunkColumnGen`.

## Fix

`CheckWorldgenConcurrencySafety` now calls `IsWorldgenHandlerHarmonyPatched`, which checks the handler method, every method on its declaring type, and every method on its nested compiler-generated types. A patch anywhere in that set drops the pass to serial, matching the gate's existing bias toward false positives over corrupted terrain.

## Tests

- `SafetyGateDetectsPatchesOnMethodsTheHandlerCallsNotJustTheHandler` verifies the patch scans the declaring type and its nested types.
- `StaticScratchFieldsRaceAcrossColumnsLikeTerraPretyCoastmap` reproduces the static-scratch race shape: a generator that writes static fields in one phase and reads them in the next diverges from its serial hash when three columns run at once.

## Validation

- `dotnet build VintageStory.slnx -c Release`: 0 warnings, 0 errors.
- `Optimum.Tests`: 665 passed, 34 skipped, 0 failed.
- `scripts/check-patches.sh`: 68 applied, 48 Cecil, 0 conflict.
- `scripts/check-vanilla-compat.sh`: ok, 18 skipped.
- `scripts/validate-shader-assets.sh`: pass.

## Limitations

The all-rock reproduction was not run against the actual TerraPrety mod with a live client; the mechanism is established from the decompiled TerraPrety source and the decompiled GenTerra source. This change is conservative: a false positive only drops a pass to serial.
