### PR TITLE
fix(server): roll back failed chunk pool initialization

### DIFF
--- a/Optimum.Tests/chunk-read-pool-lifecycle-tests.cs
+++ b/Optimum.Tests/chunk-read-pool-lifecycle-tests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
+using Reflection = System.Reflection;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Optimum.Patcher;
@@ -10,6 +13,52 @@ namespace Optimum.Tests;
 
 public sealed class ChunkReadPoolLifecycleTests
 {
+    [Fact]
+    public void ConstructorClosesConnectionWhenInitializationFailsAfterOpen()
+    {
+        string? donorPath = TryFindRepositoryFile(
+            "build/VintagestoryLib/bin/Release/net10.0/VintagestoryLib.dll");
+        if (donorPath is null) return;
+
+        InitializeSqliteProvider();
+        Reflection.Assembly donor = Reflection.Assembly.LoadFrom(donorPath);
+        Type poolType = donor.GetType("Vintagestory.Server.OptimumChunkReadPool")!;
+        Reflection.ConstructorInfo constructor = poolType
+            .GetConstructors(Reflection.BindingFlags.Instance | Reflection.BindingFlags.Public | Reflection.BindingFlags.NonPublic)
+            .Single(candidate =>
+            {
+                Reflection.ParameterInfo[] parameters = candidate.GetParameters();
+                return parameters.Length == 4 &&
+                    parameters[3].ParameterType.IsGenericType &&
+                    parameters[3].ParameterType.GetGenericTypeDefinition() == typeof(Action<>);
+            });
+
+        Type connectionType = constructor.GetParameters()[3].ParameterType.GetGenericArguments()[0];
+        Type callbackType = typeof(Action<>).MakeGenericType(connectionType);
+        var openedConnections = new List<object>();
+        Delegate failAfterOpen = CreateFailingCallback(callbackType, connectionType, openedConnections);
+        string databasePath = Path.Combine(
+            Path.GetTempPath(), $"optimum-pool-{Guid.NewGuid():N}.db");
+        File.WriteAllBytes(databasePath, Array.Empty<byte>());
+
+        try
+        {
+            Reflection.TargetInvocationException exception = Assert.Throws<Reflection.TargetInvocationException>(() =>
+                constructor.Invoke(new object[] { databasePath, 2, false, failAfterOpen }));
+
+            Assert.True(
+                exception.InnerException is InvalidOperationException,
+                exception.InnerException?.ToString());
+            Assert.Single(openedConnections);
+            Reflection.PropertyInfo state = openedConnections[0].GetType().GetProperty("State")!;
+            Assert.Equal("Closed", state.GetValue(openedConnections[0])!.ToString());
+        }
+        finally
+        {
+            File.Delete(databasePath);
+        }
+    }
+
     [Fact]
     public void ShutdownHookInsertsThePoolDisposeBeforeTheDatabaseDispose()
     {
@@ -131,4 +180,69 @@ public sealed class ChunkReadPoolLifecycleTests
         Assert.Contains("InsertInstanceVoidCallBefore", ilHook);
         Assert.Contains("expected exactly one call", ilHook);
     }
+
+    private static Delegate CreateFailingCallback(
+        Type callbackType,
+        Type connectionType,
+        List<object> openedConnections)
+    {
+        ParameterExpression connection = Expression.Parameter(connectionType, "connection");
+        Reflection.MethodInfo add = typeof(List<object>).GetMethod(nameof(List<object>.Add))!;
+        Expression recordConnection = Expression.Call(
+            Expression.Constant(openedConnections),
+            add,
+            Expression.Convert(connection, typeof(object)));
+        Expression throwFailure = Expression.Throw(
+            Expression.New(typeof(InvalidOperationException)),
+            typeof(void));
+        return Expression.Lambda(
+            callbackType,
+            Expression.Block(recordConnection, throwFailure),
+            connection).Compile();
+    }
+
+    private static void InitializeSqliteProvider()
+    {
+        string? batteriesPath = TryFindRepositoryFile(
+            OperatingSystem.IsWindows()
+                ? ".vanilla/win-x64/vintagestory/Lib/SQLitePCLRaw.batteries_v2.dll"
+                : ".vanilla/linux-x64/vintagestory/Lib/SQLitePCLRaw.batteries_v2.dll");
+        batteriesPath ??= TryFindRepositoryFile(
+            ".vanilla/win-x64/vintagestory/Lib/SQLitePCLRaw.batteries_v2.dll");
+        if (batteriesPath is null) return;
+
+        string providerDirectory = Path.GetDirectoryName(batteriesPath)!;
+        string providerPath = Path.Combine(providerDirectory, "SQLitePCLRaw.provider.e_sqlite3.dll");
+        string[] nativeNames = OperatingSystem.IsWindows()
+            ? ["e_sqlite3.dll"]
+            : OperatingSystem.IsMacOS()
+                ? ["libe_sqlite3.dylib", "libe_sqlite3.so"]
+                : ["libe_sqlite3.so"];
+        string? nativePath = nativeNames
+            .Select(name => Path.Combine(providerDirectory, name))
+            .FirstOrDefault(File.Exists);
+        if (!File.Exists(providerPath) || nativePath is null) return;
+
+        Reflection.Assembly provider = Reflection.Assembly.LoadFrom(providerPath);
+        System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver(
+            provider,
+            (name, _, _) => name is "e_sqlite3" or "e_sqlite3.dll"
+                ? System.Runtime.InteropServices.NativeLibrary.Load(nativePath)
+                : IntPtr.Zero);
+        Reflection.Assembly batteries = Reflection.Assembly.LoadFrom(batteriesPath);
+        batteries.GetType("SQLitePCL.Batteries_V2")!.GetMethod("Init")!.Invoke(null, null);
+    }
+
+    private static string? TryFindRepositoryFile(string relativePath)
+    {
+        try
+        {
+            return PatchReader.FindRepositoryFile(relativePath);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+    }
+
 }

--- a/Optimum.Tests/chunk-read-pool-lifecycle-tests.cs
+++ b/Optimum.Tests/chunk-read-pool-lifecycle-tests.cs
@@ -20,7 +20,7 @@ public sealed class ChunkReadPoolLifecycleTests
             "build/VintagestoryLib/bin/Release/net10.0/VintagestoryLib.dll");
         if (donorPath is null) return;
 
-        InitializeSqliteProvider();
+        Assert.True(InitializeSqliteProvider(), "A platform SQLite provider is required for the donor lifecycle test.");
         Reflection.Assembly donor = Reflection.Assembly.LoadFrom(donorPath);
         Type poolType = donor.GetType("Vintagestory.Server.OptimumChunkReadPool")!;
         Reflection.ConstructorInfo constructor = poolType
@@ -201,36 +201,49 @@ public sealed class ChunkReadPoolLifecycleTests
             connection).Compile();
     }
 
-    private static void InitializeSqliteProvider()
+    private static bool InitializeSqliteProvider()
     {
-        string? batteriesPath = TryFindRepositoryFile(
-            OperatingSystem.IsWindows()
-                ? ".vanilla/win-x64/vintagestory/Lib/SQLitePCLRaw.batteries_v2.dll"
-                : ".vanilla/linux-x64/vintagestory/Lib/SQLitePCLRaw.batteries_v2.dll");
-        batteriesPath ??= TryFindRepositoryFile(
-            ".vanilla/win-x64/vintagestory/Lib/SQLitePCLRaw.batteries_v2.dll");
-        if (batteriesPath is null) return;
-
-        string providerDirectory = Path.GetDirectoryName(batteriesPath)!;
-        string providerPath = Path.Combine(providerDirectory, "SQLitePCLRaw.provider.e_sqlite3.dll");
+        string[] providerDirectories = OperatingSystem.IsWindows()
+            ? [
+                ".vanilla/win-x64/vintagestory/Lib",
+                ".vanilla/win-x64/package-client/Lib",
+            ]
+            : [
+                ".vanilla/linux-x64/vintagestory/Lib",
+                ".vanilla/win-x64/vintagestory/Lib",
+                ".vanilla/win-x64/package-client/Lib",
+            ];
         string[] nativeNames = OperatingSystem.IsWindows()
             ? ["e_sqlite3.dll"]
             : OperatingSystem.IsMacOS()
                 ? ["libe_sqlite3.dylib", "libe_sqlite3.so"]
                 : ["libe_sqlite3.so"];
-        string? nativePath = nativeNames
-            .Select(name => Path.Combine(providerDirectory, name))
-            .FirstOrDefault(File.Exists);
-        if (!File.Exists(providerPath) || nativePath is null) return;
 
-        Reflection.Assembly provider = Reflection.Assembly.LoadFrom(providerPath);
-        System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver(
-            provider,
-            (name, _, _) => name is "e_sqlite3" or "e_sqlite3.dll"
-                ? System.Runtime.InteropServices.NativeLibrary.Load(nativePath)
-                : IntPtr.Zero);
-        Reflection.Assembly batteries = Reflection.Assembly.LoadFrom(batteriesPath);
-        batteries.GetType("SQLitePCL.Batteries_V2")!.GetMethod("Init")!.Invoke(null, null);
+        foreach (string relativeDirectory in providerDirectories)
+        {
+            string? batteriesPath = TryFindRepositoryFile(
+                Path.Combine(relativeDirectory, "SQLitePCLRaw.batteries_v2.dll"));
+            if (batteriesPath is null) continue;
+
+            string providerDirectory = Path.GetDirectoryName(batteriesPath)!;
+            string providerPath = Path.Combine(providerDirectory, "SQLitePCLRaw.provider.e_sqlite3.dll");
+            string? nativePath = nativeNames
+                .Select(name => Path.Combine(providerDirectory, name))
+                .FirstOrDefault(File.Exists);
+            if (!File.Exists(providerPath) || nativePath is null) continue;
+
+            Reflection.Assembly provider = Reflection.Assembly.LoadFrom(providerPath);
+            System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver(
+                provider,
+                (name, _, _) => name is "e_sqlite3" or "e_sqlite3.dll"
+                    ? System.Runtime.InteropServices.NativeLibrary.Load(nativePath)
+                    : IntPtr.Zero);
+            Reflection.Assembly batteries = Reflection.Assembly.LoadFrom(batteriesPath);
+            batteries.GetType("SQLitePCL.Batteries_V2")!.GetMethod("Init")!.Invoke(null, null);
+            return true;
+        }
+
+        return false;
     }
 
     private static string? TryFindRepositoryFile(string relativePath)

--- a/sources/VintagestoryLib/Vintagestory.Server/OptimumChunkReadPool.cs
+++ b/sources/VintagestoryLib/Vintagestory.Server/OptimumChunkReadPool.cs
@@ -29,6 +29,15 @@ internal sealed class OptimumChunkReadPool : IDisposable
     public bool IsOpen => !disposed && connections.Length > 0;
 
     public OptimumChunkReadPool(string filename, int workers, bool corruptionProtection)
+        : this(filename, workers, corruptionProtection, null)
+    {
+    }
+
+    internal OptimumChunkReadPool(
+        string filename,
+        int workers,
+        bool corruptionProtection,
+        Action<SqliteConnection>? afterConnectionOpened)
     {
         workers = Math.Max(1, Math.Min(8, workers));
         connections = new SqliteConnection[workers];
@@ -36,38 +45,47 @@ internal sealed class OptimumChunkReadPool : IDisposable
         freeSlots = new ConcurrentBag<int>();
         available = new SemaphoreSlim(workers, workers);
 
-        for (int i = 0; i < workers; i++)
+        try
         {
-            DbConnectionStringBuilder conf = new DbConnectionStringBuilder
+            for (int i = 0; i < workers; i++)
             {
-                { "Data Source", filename },
-                { "Pooling", "false" },
-                { "Mode", "ReadOnly" },
-            };
-            SqliteConnection conn = new SqliteConnection(conf.ToString());
-            conn.Open();
+                DbConnectionStringBuilder conf = new DbConnectionStringBuilder
+                {
+                    { "Data Source", filename },
+                    { "Pooling", "false" },
+                    { "Mode", "ReadOnly" },
+                };
+                SqliteConnection conn = new SqliteConnection(conf.ToString());
+                connections[i] = conn;
+                conn.Open();
+                afterConnectionOpened?.Invoke(conn);
 
-            using (SqliteCommand pragma = conn.CreateCommand())
-            {
-                pragma.CommandTimeout = 1;
-                pragma.CommandText = corruptionProtection
-                    ? "PRAGMA journal_mode=WAL;PRAGMA synchronous=Normal;PRAGMA query_only=ON;"
-                    : "PRAGMA query_only=ON;";
-                pragma.ExecuteNonQuery();
+                using (SqliteCommand pragma = conn.CreateCommand())
+                {
+                    pragma.CommandTimeout = 1;
+                    pragma.CommandText = corruptionProtection
+                        ? "PRAGMA journal_mode=WAL;PRAGMA synchronous=Normal;PRAGMA query_only=ON;"
+                        : "PRAGMA query_only=ON;";
+                    pragma.ExecuteNonQuery();
+                }
+
+                SqliteCommand cmd = conn.CreateCommand();
+                getChunkCmds[i] = cmd;
+                cmd.CommandText = "SELECT data FROM chunk WHERE position=@position";
+                SqliteParameter p = cmd.CreateParameter();
+                p.ParameterName = "position";
+                p.DbType = DbType.UInt64;
+                p.Value = 0UL;
+                cmd.Parameters.Add(p);
+                cmd.Prepare();
+
+                freeSlots.Add(i);
             }
-
-            SqliteCommand cmd = conn.CreateCommand();
-            cmd.CommandText = "SELECT data FROM chunk WHERE position=@position";
-            SqliteParameter p = cmd.CreateParameter();
-            p.ParameterName = "position";
-            p.DbType = DbType.UInt64;
-            p.Value = 0UL;
-            cmd.Parameters.Add(p);
-            cmd.Prepare();
-
-            connections[i] = conn;
-            getChunkCmds[i] = cmd;
-            freeSlots.Add(i);
+        }
+        catch
+        {
+            Dispose();
+            throw;
         }
     }
 


### PR DESCRIPTION
## Summary

- Roll back partially initialized `OptimumChunkReadPool` instances when connection, pragma, command, or preparation setup fails.
- Keep each connection and command reachable by `Dispose()` before the operation that can fail.
- Add a donor-backed regression test that throws after `Open()` and verifies the opened connection is closed.

Addresses #25. This is a narrow lifecycle follow-up to the shutdown fix already merged in #48. It does not change the TerraPrety integration or any gameplay behavior.

## Verification

- `make build`: passed with 0 warnings and 0 errors.
- `make test`: `Optimum.Tests` 666 passed, 34 skipped; `Optimum.Launcher.Tests` 21 passed.
- Windows PowerShell/.NET 10.0.203: `dotnet build VintageStory.slnx -c Release` passed with 0 errors; `Optimum.Tests` 666 passed, 34 skipped; `Optimum.Launcher.Tests` 21 passed. The build emitted only the existing unrelated decompiler/API/compatibility warnings.
- `make patch-il`: 126/126 required methods patched and 2 hooks applied.
- `bash scripts/check-patches.sh --strict-unavailable`: 68 text patches, 48 Cecil patches, 22 runtime donors, 0 conflicts.
- `make check-compat`: 0 cast divergences, 17 documented skips.
- `make check-shaders`: passed.
- `bash scripts/tests/run-server-smoke.sh --startup-timeout 180 --duration 10`: reached `RunGame`, exited 0, and reported 0 error lines.

The exact same-save menu reload remains unverified in this headless session, so this PR does not claim to close the issue by itself.