### PR TITLE
fix(bootstrap): harden cross-platform Git clone paths

### DIFF
--- a/.github/workflows/ci-bootstrap-scripts.yml
+++ b/.github/workflows/ci-bootstrap-scripts.yml
@@ -1,0 +1,28 @@
+name: Bootstrap scripts
+
+on:
+  push:
+    paths: &script_paths
+      - 'scripts/bootstrap.sh'
+      - 'scripts/bootstrap.ps1'
+      - 'scripts/git-repository.sh'
+      - 'scripts/git-repository.ps1'
+      - 'scripts/tests/bootstrap-git-repository.sh'
+      - '.github/workflows/ci-bootstrap-scripts.yml'
+  pull_request:
+    paths: *script_paths
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  git-repository:
+    name: Clone helpers survive a hostile Git environment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: bootstrap-git-test
+        run: make bootstrap-git-test

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -47,7 +47,18 @@ param(
 
 $ErrorActionPreference = 'Stop'
 . "$PSScriptRoot/_exec.ps1"
+# Explicit repository-path helper for cloned working trees (mirrors bootstrap.sh).
+. "$PSScriptRoot/git-repository.ps1"
 $repoRoot = Split-Path -Parent $PSScriptRoot
+
+# A GIT_DIR inherited from the calling environment (some tools and shell rc
+# files export it) overrides repository discovery for every git call below:
+# the clone succeeds, then the very next `git` against that clone dies with
+# "fatal: not in a git directory". Drop it, along with its siblings, so this
+# script only ever talks to repositories it names explicitly.
+foreach ($gitEnv in 'GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE') {
+    Remove-Item -Path "Env:$gitEnv" -ErrorAction SilentlyContinue
+}
 
 # Resolve VS version from forks.json if not passed explicitly.
 if (-not $Version) {
@@ -715,9 +726,9 @@ try {
                 Write-Host "Cloning $name at $($fork.ref)"
                 Invoke-NativeStep { git -c core.autocrlf=false -c core.eol=lf clone --quiet $fork.url $base 2>$null }
                 if ($LASTEXITCODE -ne 0) { throw "git clone failed for $name ($($fork.url))." }
-                Invoke-NativeStep { git -C $base config core.autocrlf false }
-                Invoke-NativeStep { git -C $base config core.eol lf }
-                Invoke-NativeStep { git -C $base checkout --quiet $fork.ref }
+                Invoke-NativeStep { Invoke-GitInClone $base config core.autocrlf false }
+                Invoke-NativeStep { Invoke-GitInClone $base config core.eol lf }
+                Invoke-NativeStep { Invoke-GitInClone $base checkout --quiet $fork.ref }
                 if ($LASTEXITCODE -ne 0) { throw "git checkout $($fork.ref) failed for $name." }
                 Remove-Item -Recurse -Force (Join-Path $base '.git')
                 Convert-ToLf $base
@@ -737,7 +748,7 @@ try {
                 if (-not (Test-Path $dest)) {
                     Write-Host "Cloning reference: $($r.name)"
                     Invoke-NativeStep { git -c core.autocrlf=false -c core.eol=lf clone --quiet --depth=1 $r.url $dest 2>$null }
-                    Invoke-NativeStep { git -C $dest checkout --quiet $r.ref 2>$null }
+                    Invoke-NativeStep { Invoke-GitInClone $dest checkout --quiet $r.ref 2>$null }
                 }
             }
         }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -503,7 +503,7 @@ if [[ -f "$forks_file" ]]; then
     if [[ ! -d "$dest" ]]; then
       echo "Cloning reference: $name"
       git -c core.autocrlf=false -c core.eol=lf clone --quiet --depth=1 "$url" "$dest" 2>/dev/null
-      git -C "$dest" checkout --quiet "$ref" 2>/dev/null
+      optimum_git_in_clone "$dest" checkout --quiet "$ref" 2>/dev/null
     fi
   done < <(
     python3 - "$forks_file" <<'PY'

--- a/scripts/git-repository.ps1
+++ b/scripts/git-repository.ps1
@@ -1,0 +1,13 @@
+# Run a Git command against a cloned working tree without relying on Git's
+# current-directory discovery. This also makes the command immune to an
+# inherited GIT_DIR selecting a different repository.
+#
+# PowerShell mirror of scripts/git-repository.sh's optimum_git_in_clone so
+# bootstrap.ps1 and bootstrap.sh stay in lockstep.
+function Invoke-GitInClone {
+    param(
+        [Parameter(Mandatory)][string]$CloneDir,
+        [Parameter(ValueFromRemainingArguments)][string[]]$GitArgs
+    )
+    & git --git-dir "$CloneDir/.git" --work-tree "$CloneDir" @GitArgs
+}

--- a/scripts/tests/bootstrap-git-repository.sh
+++ b/scripts/tests/bootstrap-git-repository.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016  # coupling assertions grep for literal script text
 
 set -euo pipefail
 
@@ -10,10 +11,40 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 # The production script clears these before cloning. Restore an invalid value
 # after the clone to exercise the explicit repository-path helper directly.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
-# Keep this assertion coupled to bootstrap.sh so the test cannot silently
-# drift into testing an unused helper.
-grep -F "source \"\$script_dir/git-repository.sh\"" "$REPO_ROOT/scripts/bootstrap.sh" >/dev/null
-grep -F "optimum_git_in_clone \"\$base\" checkout" "$REPO_ROOT/scripts/bootstrap.sh" >/dev/null
+# Keep these assertions coupled to the bootstrap scripts so the test cannot
+# silently drift into testing an unused helper. Every git call against a fresh
+# clone - the compile forks and the reference repos, in both the Bash and the
+# PowerShell bootstrap - must go through the explicit repository-path helper,
+# never plain "git -C".
+require_line() {
+  local needle="$1" file="$2"
+  grep -qF -- "$needle" "$file" || {
+    echo "expected '$needle' in $file" >&2
+    exit 1
+  }
+}
+forbid_pattern() {
+  local pattern="$1" file="$2"
+  if grep -nE -- "$pattern" "$file"; then
+    echo "$file still runs 'git -C' against a fresh clone" >&2
+    exit 1
+  fi
+}
+
+BASH_BOOTSTRAP="$REPO_ROOT/scripts/bootstrap.sh"
+require_line 'source "$script_dir/git-repository.sh"' "$BASH_BOOTSTRAP"
+require_line 'optimum_git_in_clone "$base" checkout' "$BASH_BOOTSTRAP"
+require_line 'optimum_git_in_clone "$dest" checkout' "$BASH_BOOTSTRAP"
+forbid_pattern 'git -C "\$(base|dest)"' "$BASH_BOOTSTRAP"
+
+PS_BOOTSTRAP="$REPO_ROOT/scripts/bootstrap.ps1"
+require_line 'git-repository.ps1' "$PS_BOOTSTRAP"
+require_line 'Remove-Item -Path "Env:$gitEnv"' "$PS_BOOTSTRAP"
+require_line 'Invoke-GitInClone $base checkout' "$PS_BOOTSTRAP"
+require_line 'Invoke-GitInClone $dest checkout' "$PS_BOOTSTRAP"
+forbid_pattern 'git -C \$(base|dest)' "$PS_BOOTSTRAP"
+
+# shellcheck disable=SC1091
 source "$REPO_ROOT/scripts/git-repository.sh"
 
 remote="$TEST_ROOT/remote.git"
@@ -48,5 +79,27 @@ optimum_git_in_clone "$clone" checkout --quiet main
 [[ "$(optimum_git_in_clone "$clone" config --get core.autocrlf)" == false ]]
 [[ "$(optimum_git_in_clone "$clone" config --get core.eol)" == lf ]]
 [[ "$(<"$clone/README")" == 'bootstrap git repository test' ]]
+
+# Exercise the PowerShell helper the same way when a shell is available.
+if command -v pwsh >/dev/null 2>&1; then
+  ps_clone="$TEST_ROOT/clone-ps"
+  env -u GIT_DIR -u GIT_WORK_TREE git clone --quiet "$remote" "$ps_clone"
+  pwsh -NoProfile -NonInteractive -Command "
+    \$ErrorActionPreference = 'Stop'
+    . '$REPO_ROOT/scripts/_exec.ps1'
+    . '$REPO_ROOT/scripts/git-repository.ps1'
+    # Same hostile environment and call shape as bootstrap.ps1's clone loop.
+    \$env:GIT_DIR = '$TEST_ROOT/does-not-exist.git'
+    \$env:GIT_WORK_TREE = '$TEST_ROOT/does-not-exist-worktree'
+    Invoke-NativeStep { Invoke-GitInClone '$ps_clone' config core.autocrlf false }
+    Invoke-NativeStep { Invoke-GitInClone '$ps_clone' config core.eol lf }
+    Invoke-NativeStep { Invoke-GitInClone '$ps_clone' checkout --quiet main }
+    if ((Invoke-GitInClone '$ps_clone' config --get core.autocrlf) -ne 'false') { throw 'core.autocrlf not set via helper' }
+    if ((Get-Content '$ps_clone/README' -Raw).Trim() -ne 'bootstrap git repository test') { throw 'checkout via helper did not populate the work tree' }
+  "
+  echo 'PowerShell Git repository helper test passed.'
+else
+  echo 'pwsh not found; skipped PowerShell helper test.'
+fi
 
 echo 'Bootstrap Git repository test passed.'


### PR DESCRIPTION
## Problem

Issue #23 reports `fatal: not in a git directory` from the installer's bootstrap right after `git clone`, on a mounted filesystem. PR #61 fixed this for the Bash bootstrap's compile-fork clones by giving every post-clone git call an explicit `--git-dir` and `--work-tree` through `scripts/git-repository.sh`, so an inherited `GIT_DIR` or `GIT_WORK_TREE` cannot redirect discovery to the wrong repository.

Two paths were still relying on implicit discovery:

The PowerShell bootstrap (`scripts/bootstrap.ps1`) is a full parallel implementation of the same clone flow. It ran every clone, config, and checkout through plain `git -C`, and it never cleared `GIT_DIR`, `GIT_WORK_TREE`, or `GIT_INDEX_FILE`, unlike `bootstrap.sh` which drops them at the top. On a Windows host with any of those exported, it fails the same way #23 describes.

The reference-repo checkout in `bootstrap.sh` (step 3b) still used `git -C "$dest" checkout`. That path is dormant today because `forks.json` has no `reference` entries, but it is one edit away from being live again.

## Change

`scripts/git-repository.ps1` is new: an `Invoke-GitInClone` helper that mirrors `optimum_git_in_clone` from `scripts/git-repository.sh`.

`scripts/bootstrap.ps1` now clears `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` at startup and routes the compile-fork and reference-repo git calls through `Invoke-GitInClone`.

`scripts/bootstrap.sh` uses `optimum_git_in_clone` for the reference-repo checkout.

`scripts/tests/bootstrap-git-repository.sh` gains coupling assertions that fail if either script reintroduces `git -C` against a fresh clone, and, when `pwsh` is available, it runs the PowerShell helper against a real clone under an invalid `GIT_DIR` and checks the config and work tree land correctly.

`.github/workflows/ci-bootstrap-scripts.yml` is new. It runs `make bootstrap-git-test` on pushes and PRs that touch the bootstrap scripts. That target ran in no workflow before this.

## Verification

`make bootstrap-git-test` passes, including the new PowerShell case. `make check` passes. `bash -n scripts/bootstrap.sh` and the PowerShell parser on both `.ps1` files pass. `shellcheck` on the test and `scripts/git-repository.sh` is clean.

`make build`, `make test`, and the patch and compatibility gates were not re-run for this branch. The diff is limited to the bootstrap scripts, one test, and one workflow, and touches no patch, source, or C# file. The full suite passed on a refreshed tree earlier the same day.

The reporter's exact `/mnt/zoomin` mount is not reproducible here, so the filesystem-specific trigger stays unconfirmed. This change removes the remaining implicit-discovery paths regardless.

Addresses #23.
