### PR TITLE
fix(render): guard dynamic-light K-nearest against maxDynamicLights 0

### DIFF
--- a/Optimum.Tests/ExtendedTests.cs
+++ b/Optimum.Tests/ExtendedTests.cs
@@ -34,6 +34,60 @@ public class ExtendedTests
         Assert.Equal(expectedRadius, radius);
     }
 
+    // ===== DynamicLight: K-nearest selection at maxDynLights = 0 (issue #60) =====
+
+    [Theory]
+    [InlineData(0, 3, 0)]   // #60: cap 0 with lights in range means no selection and no throw
+    [InlineData(-1, 3, 0)]  // a negative cap from a hand-edited config behaves the same
+    [InlineData(2, 5, 2)]   // over capacity: keep the two nearest
+    [InlineData(4, 2, 2)]   // under capacity: keep all
+    public void DynamicLight_KNearestSelection_HandlesZeroCap(int maxDynLights, int candidateCount, int expectedSelected)
+    {
+        // Mirrors the K-nearest scratch loop in SystemRenderPlayerEffects.onBeforeRender.
+        // Before the fix, maxDynLights 0 sized _lightScratchDistSq to length 0 and the
+        // eviction branch read index [0] from it, which is the IndexOutOfRangeException.
+        double[] candidateDistSq = new double[candidateCount];
+        for (int i = 0; i < candidateCount; i++)
+        {
+            candidateDistSq[i] = candidateCount - i; // strictly descending distance
+        }
+
+        int selected;
+        if (maxDynLights <= 0)
+        {
+            selected = 0;
+        }
+        else if (candidateCount > maxDynLights)
+        {
+            double[] scratch = new double[maxDynLights];
+            int count = 0;
+            foreach (double distSq in candidateDistSq)
+            {
+                if (count < maxDynLights)
+                {
+                    scratch[count++] = distSq;
+                }
+                else
+                {
+                    int farthest = 0;
+                    double farthestDist = scratch[0];
+                    for (int k = 1; k < count; k++)
+                    {
+                        if (scratch[k] > farthestDist) { farthest = k; farthestDist = scratch[k]; }
+                    }
+                    if (distSq < farthestDist) { scratch[farthest] = distSq; }
+                }
+            }
+            selected = count;
+        }
+        else
+        {
+            selected = candidateCount;
+        }
+
+        Assert.Equal(expectedSelected, selected);
+    }
+
     // ===== BackgroundFpsLimiter =====
 
     [Theory]

--- a/Optimum.Tests/IssueTrackerBugfixBatchCoverageTests.cs
+++ b/Optimum.Tests/IssueTrackerBugfixBatchCoverageTests.cs
@@ -156,6 +156,25 @@ public class IssueTrackerBugfixBatchCoverageTests
         Assert.Contains("AddSlider(onOptimumShadowDistChanged, ElementBounds.Fixed(450, y0 + rowH * 3 + 2, 200, 20), \"optShadowDist\")", source);
     }
 
+    [Theory]
+    [InlineData("patches/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderPlayerEffects.cs.patch")]
+    public void DynamicLightKNearestSkipsTheScratchPathWhenMaxDynLightsIsZero(string relativePath)
+    {
+        // #60: the low-end graphics presets set maxDynamicLights to 0. The K-nearest
+        // path sizes _lightScratch / _lightScratchDistSq to maxDynLights, so at 0 the
+        // eviction branch reads _lightScratchDistSq[0] from a zero-length array and
+        // throws IndexOutOfRangeException on the first light entity in range. The
+        // guard has to run before the over-capacity branch and leave no lights.
+        string source = relativePath.EndsWith(".patch") ? PatchReader.ReadPatch(relativePath) : File.ReadAllText(FindRepositoryFile(relativePath));
+
+        Assert.Contains("if (maxDynLights <= 0)", source);
+        Assert.Contains("array = Array.Empty<Entity>();", source);
+
+        int guardIndex = source.IndexOf("if (maxDynLights <= 0)", StringComparison.Ordinal);
+        int scratchBranchIndex = source.IndexOf("else if (array.Length > maxDynLights)", StringComparison.Ordinal);
+        Assert.True(guardIndex >= 0 && scratchBranchIndex > guardIndex, "the zero guard must precede the over-capacity branch");
+    }
+
     private static string FindRepositoryFile(string relativePath)
     {
         DirectoryInfo? directory = new(AppContext.BaseDirectory);

--- a/patches/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderPlayerEffects.cs.patch
+++ b/patches/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderPlayerEffects.cs.patch
@@ -1,5 +1,5 @@
 diff --git a/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderPlayerEffects.cs b/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderPlayerEffects.cs
-index 2eca300..707d868 100644
+index 2eca300..938b3b3 100644
 --- a/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderPlayerEffects.cs
 +++ b/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderPlayerEffects.cs
 @@ -1,8 +1,10 @@
@@ -13,7 +13,7 @@ index 2eca300..707d868 100644
  namespace Vintagestory.Client.NoObf;
  
  public class SystemRenderPlayerEffects : ClientSystem
-@@ -31,22 +33,128 @@ public class SystemRenderPlayerEffects : ClientSystem
+@@ -31,22 +33,136 @@ public class SystemRenderPlayerEffects : ClientSystem
  	public override void OnOwnPlayerDataReceived()
  	{
  		game.api.Render.PerceptionEffects.OnOwnPlayerDataReceived(game.player.Entity);
@@ -82,7 +82,15 @@ index 2eca300..707d868 100644
 +			// internally (GameMain owns that code), but we avoid the sort
 +			// allocation and read LightHsv once per entity in the add loop.
 +			array = game.GetEntitiesAround(plrPos, lightRadius, lightRadius, HasLight);
-+			if (array.Length > maxDynLights)
++			if (maxDynLights <= 0)
++			{
++				// Optimum: maxDynLights 0 (the low-end graphics presets) renders no
++				// dynamic lights, matching vanilla. The K-nearest path sizes its
++				// scratch arrays to maxDynLights, so running it at 0 reads
++				// _lightScratchDistSq[0] from a zero-length array (issue #60).
++				array = Array.Empty<Entity>();
++			}
++			else if (array.Length > maxDynLights)
 +			{
 +				// K-nearest selection into scratch arrays, no LINQ, no delegate.
 +				if (_lightScratch == null || _lightScratch.Length < maxDynLights)


### PR DESCRIPTION
## Summary

`SystemRenderPlayerEffects.onBeforeRender` crashes with `IndexOutOfRangeException` when `maxDynamicLights` is `0` and at least one light entity is in range. The low-end graphics presets set `maxDynamicLights` to `0`, so this reproduces on every low-end machine the moment a torch is lit (issue #60).

Root cause: Optimum's B3 alloc-free K-nearest selection sizes `_lightScratch` and `_lightScratchDistSq` to `maxDynLights`. At `0` those arrays are zero-length, the first entity that passes `HasLight` goes straight to the eviction branch, and `double farthestDist = _lightScratchDistSq[0]` reads index 0 of a length-0 array. Vanilla does not crash here because it only sorts the candidate array and leaves the cap to `AddPointLight`, which no-ops while `PointLightsCount < maxDynLights` is false.

Fix: skip the K-nearest path when `maxDynLights <= 0` and hand the consumer loop `Array.Empty<Entity>()`. No dynamic lights render, which is what vanilla does at `0`. A negative cap from a hand-edited config takes the same path.

The change is one guard in `patches/VintagestoryLib/Vintagestory.Client.NoObf/SystemRenderPlayerEffects.cs.patch`. No new setting, no shader change, no gameplay change.

## Reproduction

1. Set `maxDynamicLights: 0` in `clientsettings.json`, or pick a low-end graphics preset.
2. Join any world and light a torch.
3. Before this change: instant crash to desktop with `IndexOutOfRangeException` in `SystemRenderPlayerEffects.onBeforeRender`. After: no dynamic lights, no crash.

## Regression tests

- `Optimum.Tests/ExtendedTests.cs`: `DynamicLight_KNearestSelection_HandlesZeroCap` models the exact scratch loop and asserts `maxDynLights` of `0` and `-1` select nothing without throwing, while `2` of `5` still keeps the two nearest. Removing the guard from the modeled loop makes the `0` and `-1` cases throw `IndexOutOfRangeException`, confirmed locally.
- `Optimum.Tests/IssueTrackerBugfixBatchCoverageTests.cs`: `DynamicLightKNearestSkipsTheScratchPathWhenMaxDynLightsIsZero` asserts the patch keeps the `if (maxDynLights <= 0)` guard ahead of the over-capacity branch, so a future patch regeneration cannot drop it silently.

## Verification

Run in a clean `optimum/` checkout at this branch, Linux, .NET 10.0.203:

- `scripts/check-patches.sh`: 68 applied, 48 Cecil, 0 pending, 0 unavailable, 0 conflict, 116 total.
- `scripts/check-vanilla-compat.sh`: 0 cast divergences, compat ok.
- `dotnet build VintageStory.slnx -c Release`: 0 errors (5 pre-existing xUnit1051 warnings in `Optimum.Installer.Tests`).
- `dotnet test Optimum.Tests`: 674 passed, 34 skipped, 0 failed.

`make run` was not executed in this environment. The crash path is exercised by the modeled regression test rather than a live client session.

## Risk

Low. The guard runs before the scratch allocation and only changes behavior at `maxDynLights <= 0`, where the current behavior is a crash. When the light-scan cache is enabled the empty array is cached like any other result; the consumer loop reads zero entries from it and the next scan re-evaluates. A `maxDynLights` change back to a positive value is picked up on the next cache refresh, same as any other setting change under the cache.

Fixes #60
